### PR TITLE
Refactor client functions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,3 +22,5 @@ exclude_lines =
     # Don't complain if non-runnable code isn't run:
     if 0:
     if __name__ == .__main__.:
+
+    def __str__

--- a/rp_redcap/models.py
+++ b/rp_redcap/models.py
@@ -1,3 +1,5 @@
+import redcap
+
 from django.db import models
 from sidekick.models import Organization
 
@@ -15,6 +17,9 @@ class Project(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_redcap_client(self):
+        return redcap.Project(self.url, self.token)
 
 
 class Survey(models.Model):

--- a/rp_redcap/models.py
+++ b/rp_redcap/models.py
@@ -19,7 +19,7 @@ class Project(models.Model):
         return self.name
 
     def get_redcap_client(self):
-        return redcap.Project(self.url, self.token)
+        return redcap.Project(self.url, self.token)  # pragma: no cover
 
 
 class Survey(models.Model):

--- a/rp_redcap/tests/test_tasks.py
+++ b/rp_redcap/tests/test_tasks.py
@@ -138,7 +138,7 @@ class SurveyCheckTaskTests(RedcapBaseTestCase, TestCase):
 
     @responses.activate
     @patch("rp_redcap.tasks.project_check.get_records")
-    @patch("rp_redcap.tasks.project_check.get_redcap_client")
+    @patch("rp_redcap.models.Project.get_redcap_client")
     def test_project_check(self, mock_get_redcap_client, mock_get_records):
         """
         Survey task test.
@@ -186,7 +186,7 @@ class SurveyCheckTaskTests(RedcapBaseTestCase, TestCase):
         self.assertEqual(contact.project, self.project)
 
     @responses.activate
-    @patch("rp_redcap.tasks.project_check.get_redcap_client")
+    @patch("rp_redcap.models.Project.get_redcap_client")
     def test_project_check_with_fields(self, mock_get_redcap_client):
         """
         Project task test.
@@ -244,7 +244,7 @@ class SurveyCheckTaskTests(RedcapBaseTestCase, TestCase):
         )
 
     @responses.activate
-    @patch("rp_redcap.tasks.project_check.get_redcap_client")
+    @patch("rp_redcap.models.Project.get_redcap_client")
     def test_project_check_multiple_surveys(self, mock_get_redcap_client):
         """
         Project task test.

--- a/rp_sidekick/settings.py
+++ b/rp_sidekick/settings.py
@@ -180,6 +180,3 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 
 djcelery.setup_loader()
-
-RAPIDPRO_API_URL = env("RAPIDPRO_API_URL", "http://localhost:8002/")
-RAPIDPRO_API_TOKEN = env("RAPIDPRO_API_TOKEN", "REPLACEME")

--- a/sidekick/models.py
+++ b/sidekick/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+from temba_client.v2 import TembaClient
+
 
 class Organization(models.Model):
     name = models.CharField(max_length=200, null=False, blank=False)
@@ -10,3 +12,6 @@ class Organization(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_rapidpro_client(self):
+        return TembaClient(self.url, self.token)


### PR DESCRIPTION
Now getting the Rapidpro url and token from the org object.

Also moved the `get_rapidpro_client` and `get_redcap_client` function to the models.