### PR TITLE
Fix error for project not found

### DIFF
--- a/rp_redcap/tests/test_views.py
+++ b/rp_redcap/tests/test_views.py
@@ -45,6 +45,23 @@ class SurveyCheckViewTests(RedcapBaseTestCase, APITestCase):
         mock_project_check.assert_not_called()
 
     @patch("rp_redcap.tasks.project_check.delay")
+    def test_project_not_found(self, mock_project_check):
+        """
+        Project not found test.
+
+        If the project id in the url doesn't exist we should respond with an
+        appropriate message.
+        """
+        survey_url = reverse("rp_redcap.start_project_check", args=[-1])
+
+        response = self.client.post(
+            survey_url, {}, content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        mock_project_check.assert_not_called()
+
+    @patch("rp_redcap.tasks.project_check.delay")
     def test_not_in_org(self, mock_project_check):
         """
         Not in organization test.

--- a/rp_redcap/views.py
+++ b/rp_redcap/views.py
@@ -8,7 +8,10 @@ from .models import Project
 
 class StartProjectCheckView(APIView):
     def post(self, request, project_id, *args, **kwargs):
-        project = Project.objects.get(id=project_id)
+        try:
+            project = Project.objects.get(id=project_id)
+        except Project.DoesNotExist:
+            return HttpResponse(status=status.HTTP_400_BAD_REQUEST)
 
         if not project.org.users.filter(id=request.user.id).exists():
             return HttpResponse(status=status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
If the api is called with a project id that does not exist it causes an unhandled exception, not anymore.