### PR TITLE
Add transferto app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,76 @@
+# Created by https://www.gitignore.io/api/windows,macos,linux,git
+
+### Git ###
+*.orig
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+# End of https://www.gitignore.io/api/windows,macos,linux,git
+
+# Start of https://raw.githubusercontent.com/audreyr/cookiecutter-pypackage/master/%7B%7Bcookiecutter.project_slug%7D%7D/.gitignore
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -6,44 +79,9 @@ __pycache__/
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-dist
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
-.installed.cfg
-lib
-lib64
-
-# Unit test / coverage reports
-.coverage
-.tox
-nosetests.xml
-.pytest_cache
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-/ve/
-logs/*.log
-*.pid
-local_settings.py
-.DS_Store
-.cache/
-
 # Distribution / packaging
 .Python
 env/
-ve/
 build/
 develop-eggs/
 dist/
@@ -55,6 +93,7 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -77,8 +116,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -86,6 +126,14 @@ coverage.xml
 
 # Django stuff:
 *.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
@@ -93,9 +141,48 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
 
-# Ignore anything in staticfiles
-staticfiles/
-!staticfiles/gitkeep.txt
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+ve/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# end from https://raw.githubusercontent.com/audreyr/cookiecutter-pypackage/master/%7B%7Bcookiecutter.project_slug%7D%7D/.gitignore
+
+.vscode/
+*.sqlite3
+*.sqlite4
+node_modules/
+__pycache__
+
+local.py
+/static/
+/media/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       script:
         - black --check .
         - flake8
-        - py.test --cov=./
+        - py.test --cov=./ --color=yes
         - python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)   # yamllint disable-line
       after_success:
         - codecov

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "sidekick",
     "rp_redcap",
+    "rp_transferto",
 ]
 
 MIDDLEWARE = [
@@ -62,7 +63,7 @@ WSGI_APPLICATION = "config.wsgi.application"
 DATABASES = {
     "default": env.db(
         "RP_SIDEKICK_DATABASE",
-        default="postgres://postgres:@localhost/rp_sidekick",
+        default="postgres://postgres@localhost:5432/rp_sidekick",
     )
 }
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -169,3 +169,6 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 
 djcelery.setup_loader()
+
+TRANSFERTO_LOGIN = env.str("TRANSFERTO_LOGIN", "")
+TRANSFERTO_TOKEN = env.str("TRANSFERTO_TOKEN", "")

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,5 +5,5 @@ urlpatterns = [
     path("", include("sidekick.urls"), name="sidekick"),
     path("admin/", admin.site.urls),
     path("redcap/", include("rp_redcap.urls"), name="rp_redcap"),
-    path("transferto/", include("transferto.urls"), name="rp_transferto"),
+    path("transferto/", include("rp_transferto.urls"), name="rp_transferto"),
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path("", include("sidekick.urls"), name="sidekick"),
     path("admin/", admin.site.urls),
     path("redcap/", include("rp_redcap.urls"), name="rp_redcap"),
+    path("transferto/", include("transferto.urls"), name="rp_transferto"),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: '3'
+
+services:
+  db:
+    env_file:
+      - .envs/.postgres
+    image: postgres:9.6
+  web:
+    build: ./
+    env_file: .envs/.django
+    command: ./manage.py runserver 0.0.0.0:8000
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db

--- a/rp_transferto/admin.py
+++ b/rp_transferto/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/rp_transferto/admin.py
+++ b/rp_transferto/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/rp_transferto/apps.py
+++ b/rp_transferto/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class RpTransfertoConfig(AppConfig):
+    name = "rp_transferto"

--- a/rp_transferto/models.py
+++ b/rp_transferto/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/rp_transferto/models.py
+++ b/rp_transferto/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/rp_transferto/tests.py
+++ b/rp_transferto/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/rp_transferto/tests.py
+++ b/rp_transferto/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/rp_transferto/tests/constants.py
+++ b/rp_transferto/tests/constants.py
@@ -1,0 +1,105 @@
+PING_RESPONSE_DICT = {
+    "info_txt": "pong",
+    "authentication_key": "1327027869",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+}
+
+
+MSISDN_INFO_RESPONSE_DICT = {
+    "country": "Malaysia",
+    "countryid": "799",
+    "operator": "Maxis Malaysia",
+    "operatorid": "385",
+    "connection_status": "100",
+    "destination_msisdn": "60172860300",
+    "destination_currency": "MYR",
+    "product_list": "5,10,20,30",
+    "service_fee_list": "0.00,0.00,0.00,0.00",
+    "retail_price_list": "2.10,4.00,7.80,11.60",
+    "wholesale_price_list": "1.95,3.72,7.25,10.79",
+    "authentication_key": "1326965217",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+    "local_info_amount_list": "5.00,10.00,20.00,30.00",
+    "local_info_value_list": "5.00,10.00,20.00,30.00",
+    "local_info_currency": "MYR",
+}
+
+
+RESERVE_ID_RESPONSE_DICT = {
+    "status_code": "0",
+    "reserved_id": "20123457",
+    "error_txt": "Transaction successful",
+    "authentication_key": "1217303174266",
+    "error_code": "0",
+}
+
+TOPUP_RESPONSE_DICT = {
+    "transactionid": "77748538",
+    "msisdn": "69999999999",
+    "destination_msisdn": "60172860300",
+    "country": "Malaysia",
+    "countryid": "799",
+    "operator": "Maxis Malaysia",
+    "originating_currency": "USD",
+    "destination_currency": "MYR",
+    "product_requested": "10",
+    "actual_product_sent": "10",
+    "wholesale_price": "3.39",
+    "service_fee": "0.00",
+    "retail_price": "4.30",
+    "balance": "8.1",
+    "sms_sent": "yes",
+    "sms": "Happy birthday ",
+    "sender_sms": "yes",
+    "sender_text": "",
+    "cid1": " My Text ",
+    "authentication_key": "1326963417",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+    "local_info_value": "10.00",
+    "local_info_amount": "10.00",
+    "local_info_currency": "MYR",
+    "return_timestamp": "2013-03-18 00:00:01",
+    "return_version": "1.06.08",
+    "reference_operator": "",
+    "operatorid": "",
+    "cid2": "",
+    "cid3": "",
+}
+
+
+GET_COUNTRIES_RESPONSE_DICT = {
+    "country": "Afghanistan,Albania,Anguilla,Antigua and Barbuda,Argentina,Armenia,Aruba",
+    "countryid": "661,662,916,668,669,670,671",
+    "authentication_key": "1337662098",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+}
+
+
+GET_OPERATORS_RESPONSE_DICT = {
+    "country": "Indonesia",
+    "countryid": "767",
+    "operator": "Indosat Starone Indonesia,Telkom Flexi Indonesia,Indosat IM3 Indonesia,AAA-TESTING Indone- sia,Esia Bakrie Telecom Indonesia,Indosat Mentari Indonesia,Telkomsel Simpati Indonesia,Three Telecom Indonesia,Telkomsel KartuAS Indonesia,Excelcom Indonesia,Axis Indonesia",
+    "operatorid": "1320,1322,1313,1310,1326,1312,1324,1327,1325,215,1411",
+    "authentication_key": "1337662386",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+}
+
+
+GET_OPERATOR_PRODUCTS_RESPONSE_DICT = {
+    "country": "Indonesia",
+    "countryid": "767",
+    "operator": "Indosat IM3 Indonesia",
+    "operatorid": "1313",
+    "destination_currency": "IDR",
+    "product_list": "5000,10000,20000,25000,50000,100000",
+    "wholesale_price_list": "0.85,1.28,2.98,5.53,11.05",
+    "retail_price_list": "1.00,1.50,3.50,6.50,13.00",
+    "authentication_key": "1337662386",
+    "error_code": "0",
+    "error_txt": "Transaction successful",
+}

--- a/rp_transferto/tests/test_utils.py
+++ b/rp_transferto/tests/test_utils.py
@@ -47,6 +47,13 @@ class TestTransferToClient(TestCase):
 
         mock.assert_called_once_with("ping")
 
+    def test_reserve_id(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.reserve_id()
+
+        mock.assert_called_once_with("reserve_id")
+
     def test_get_countries(self):
         client = TransferToClient("fake_login", "fake_token")
         with patch.object(client, "_make_transferto_request") as mock:

--- a/rp_transferto/tests/test_utils.py
+++ b/rp_transferto/tests/test_utils.py
@@ -45,14 +45,23 @@ class TestTransferToClient(TestCase):
         with patch.object(client, "_make_transferto_request") as mock:
             client.ping()
 
-        mock.assert_called_once_with("ping")
+        mock.assert_called_once_with(action="ping")
+
+    def test_get_misisdn_info(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.get_misisdn_info("+27820000001")
+
+        mock.assert_called_once_with(
+            action="msisdn_info", destination_msisdn="+27820000001"
+        )
 
     def test_reserve_id(self):
         client = TransferToClient("fake_login", "fake_token")
         with patch.object(client, "_make_transferto_request") as mock:
             client.reserve_id()
 
-        mock.assert_called_once_with("reserve_id")
+        mock.assert_called_once_with(action="reserve_id")
 
     def test_get_countries(self):
         client = TransferToClient("fake_login", "fake_token")

--- a/rp_transferto/tests/test_utils.py
+++ b/rp_transferto/tests/test_utils.py
@@ -88,3 +88,60 @@ class TestTransferToClient(TestCase):
         with raises(TypeError) as exception_info:
             self.client.get_operator_products("not an int")
         self.assertEqual(exception_info.value.__str__(), "arg must be an int")
+
+    def test_make_topup_throws_exception_source_variables(self):
+        with raises(Exception) as exception_info:
+            self.client.make_topup("fake_msisdn", 10)
+        self.assertEqual(
+            exception_info.value.__str__(),
+            "source_msisdn and source_name cannot both be None",
+        )
+
+    def test_make_topup_throws_exception_product_must_be_int(self):
+        with raises(TypeError) as exception_info:
+            self.client.make_topup("fake_msisdn", "10", source_name="test_name")
+        self.assertEqual(
+            exception_info.value.__str__(), "product arg must be an int"
+        )
+
+    def test_make_topup_1(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.make_topup("+27820000001", 10, source_msisdn="+27820000002")
+
+        mock.assert_called_once_with(
+            action="topup",
+            destination_msisdn="+27820000001",
+            product=10,
+            msisdn="+27820000002",
+        )
+
+    def test_make_topup_2(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.make_topup("+27820000001", 10, source_name="john")
+
+        mock.assert_called_once_with(
+            action="topup",
+            destination_msisdn="+27820000001",
+            product=10,
+            msisdn="john",
+        )
+
+    def test_make_topup_3(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.make_topup(
+                "+27820000001",
+                10,
+                source_msisdn="+27820000002",
+                reserve_id=1234,
+            )
+
+        mock.assert_called_once_with(
+            action="topup",
+            destination_msisdn="+27820000001",
+            product=10,
+            msisdn="+27820000002",
+            reserve_id=1234,
+        )

--- a/rp_transferto/tests/test_utils.py
+++ b/rp_transferto/tests/test_utils.py
@@ -1,0 +1,83 @@
+import responses
+from mock import patch
+from pytest import raises
+from unittest import TestCase
+
+from rp_transferto.utils import TransferToClient
+
+
+class TestTransferToClient(TestCase):
+    def setUp(self):
+        self.client = TransferToClient("fake_login", "fake_token")
+
+    def test_convert_response_body(self):
+        """
+        Returns a dict of the airtime API body response
+        """
+        test_input = b"authentication_key=1111111111111111\r\nerror_code=919\r\nerror_txt=All needed argument not received\r\n"
+        expected_output = {
+            "authentication_key": "1111111111111111",
+            "error_code": "919",
+            "error_txt": "All needed argument not received",
+        }
+        output = self.client._convert_response_body(test_input)
+        self.assertDictEqual(output, expected_output)
+
+    @responses.activate
+    def test_make_transferto_request(self):
+        responses.add(
+            responses.POST,
+            self.client.url,
+            body=b"info_txt=pong\r\nauthentication_key=1111111111111111\r\nerror_code=0\r\nerror_txt=Transaction successful\r\n",
+            status=200,
+        )
+        output = self.client._make_transferto_request(action="ping")
+        expected_output = {
+            "info_txt": "pong",
+            "authentication_key": "1111111111111111",
+            "error_code": "0",
+            "error_txt": "Transaction successful",
+        }
+        self.assertDictEqual(output, expected_output)
+
+    def test_ping(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.ping()
+
+        mock.assert_called_once_with("ping")
+
+    def test_get_countries(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.get_countries()
+
+        mock.assert_called_once_with(action="pricelist", info_type="countries")
+
+    def test_get_operators(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.get_operators(111)
+
+        mock.assert_called_once_with(
+            action="pricelist", info_type="country", content=111
+        )
+
+    def test_get_operator_products(self):
+        client = TransferToClient("fake_login", "fake_token")
+        with patch.object(client, "_make_transferto_request") as mock:
+            client.get_operator_products(111)
+
+        mock.assert_called_once_with(
+            action="pricelist", info_type="operator", content=111
+        )
+
+    def test_get_operators_throws_exception(self):
+        with raises(TypeError) as exception_info:
+            self.client.get_operators("not an int")
+        self.assertEqual(exception_info.value.__str__(), "arg must be an int")
+
+    def test_get_operator_products_throws_exception(self):
+        with raises(TypeError) as exception_info:
+            self.client.get_operator_products("not an int")
+        self.assertEqual(exception_info.value.__str__(), "arg must be an int")

--- a/rp_transferto/tests/test_views.py
+++ b/rp_transferto/tests/test_views.py
@@ -1,12 +1,105 @@
+import json
+
+from mock import patch
+from unittest.mock import MagicMock
 from django.urls import reverse
+from django.contrib.auth.models import User
+
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase, APIClient
+
+from rp_transferto.utils import TransferToClient
+from .constants import (
+    PING_RESPONSE_DICT,
+    MSISDN_INFO_RESPONSE_DICT,
+    RESERVE_ID_RESPONSE_DICT,
+    GET_COUNTRIES_RESPONSE_DICT,
+    GET_OPERATORS_RESPONSE_DICT,
+    GET_OPERATOR_PRODUCTS_RESPONSE_DICT,
+)
+
+fake_ping = MagicMock(return_value=PING_RESPONSE_DICT)
+fake_msisdn_info = MagicMock(return_value=MSISDN_INFO_RESPONSE_DICT)
+fake_reserve_id = MagicMock(return_value=RESERVE_ID_RESPONSE_DICT)
+fake_get_countries = MagicMock(return_value=GET_COUNTRIES_RESPONSE_DICT)
+fake_get_operators = MagicMock(return_value=GET_OPERATORS_RESPONSE_DICT)
+fake_get_operator_products = MagicMock(
+    return_value=GET_OPERATOR_PRODUCTS_RESPONSE_DICT
+)
 
 
-class ProductTests(APITestCase):
-    def test_get_products(self):
-        """
-        Product Endpoint should return json with list of available products
-        """
-        response = self.client.get(reverse("get_products"))
+class TestTransferToViews(APITestCase):
+    def setUp(self):
+        self.api_client = APIClient()
+
+        self.user = User.objects.create_user(
+            "username", "testuser@example.com", "password"
+        )
+        token = Token.objects.create(user=self.user)
+        self.token = token.key
+        self.api_client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+
+    @patch.object(TransferToClient, "ping", fake_ping)
+    def test_ping_view(self):
+        self.assertFalse(fake_ping.called)
+        response = self.api_client.get(reverse("ping"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(response.content), PING_RESPONSE_DICT)
+        self.assertTrue(fake_ping.called)
+
+    @patch.object(TransferToClient, "get_misisdn_info", fake_msisdn_info)
+    def test_msisdn_info_view(self):
+        self.assertFalse(fake_ping.called)
+        response = self.api_client.get(
+            reverse("msisdn_info", kwargs={"msisdn": "+27820000001"})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            json.loads(response.content), MSISDN_INFO_RESPONSE_DICT
+        )
+        self.assertTrue(fake_msisdn_info.called)
+
+    @patch.object(TransferToClient, "reserve_id", fake_reserve_id)
+    def test_reserve_id_view(self):
+        self.assertFalse(fake_reserve_id.called)
+        response = self.api_client.get(reverse("reserve_id"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(response.content), RESERVE_ID_RESPONSE_DICT)
+        self.assertTrue(fake_reserve_id.called)
+
+    @patch.object(TransferToClient, "get_countries", fake_get_countries)
+    def test_get_countries_view(self):
+        self.assertFalse(fake_get_countries.called)
+        response = self.api_client.get(reverse("get_countries"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            json.loads(response.content), GET_COUNTRIES_RESPONSE_DICT
+        )
+        self.assertTrue(fake_get_countries.called)
+
+    @patch.object(TransferToClient, "get_operators", fake_get_operators)
+    def test_get_operators_view(self):
+        self.assertFalse(fake_get_operators.called)
+        response = self.api_client.get(
+            reverse("get_operators", kwargs={"country_id": 111})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            json.loads(response.content), GET_OPERATORS_RESPONSE_DICT
+        )
+        self.assertTrue(fake_get_operators.called)
+
+    @patch.object(
+        TransferToClient, "get_operator_products", fake_get_operator_products
+    )
+    def test_get_operator_products_view(self):
+        self.assertFalse(fake_get_operator_products.called)
+        response = self.api_client.get(
+            reverse("get_operator_products", kwargs={"operator_id": 222})
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            json.loads(response.content), GET_OPERATOR_PRODUCTS_RESPONSE_DICT
+        )
+        self.assertTrue(fake_get_operator_products.called)

--- a/rp_transferto/tests/test_views.py
+++ b/rp_transferto/tests/test_views.py
@@ -1,0 +1,14 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class ProductTests(APITestCase):
+    def test_get_products(self):
+        """
+        Product Endpoint should return response
+        """
+        url = reverse("rp_transferto:get_products")
+        data = {"name": "test"}
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/rp_transferto/tests/test_views.py
+++ b/rp_transferto/tests/test_views.py
@@ -6,9 +6,7 @@ from rest_framework.test import APITestCase
 class ProductTests(APITestCase):
     def test_get_products(self):
         """
-        Product Endpoint should return response
+        Product Endpoint should return json with list of available products
         """
-        url = reverse("rp_transferto:get_products")
-        data = {"name": "test"}
-        response = self.client.post(url, data, format="json")
+        response = self.client.get(reverse("get_products"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     path(
         "msisdn_info/<str:msisdn>/",
         views.MsisdnInfo.as_view(),
-        name="misisdn_info",
+        name="msisdn_info",
     ),
     path("reserve_id/", views.ReserveId.as_view(), name="reserve_id"),
     path("get_countries/", views.GetCountries.as_view(), name="get_countries"),
@@ -19,6 +19,6 @@ urlpatterns = [
     path(
         "get_products/<int:operator_id>/",
         views.GetProducts.as_view(),
-        name="get_products",
+        name="get_operator_products",
     ),
 ]

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
         views.MsisdnInfo.as_view(),
         name="misisdn_info",
     ),
+    path("reserve_id/", views.ReserveId.as_view(), name="reserve_id"),
     path("get_countries/", views.GetCountries.as_view(), name="get_countries"),
     path(
         "get_operators/<int:country_id>/",

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("get_products", views.GetProducts.as_view(), name="get_products")
+]

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -3,5 +3,21 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("get_products", views.GetProducts.as_view(), name="get_products")
+    path("ping/", views.Ping.as_view(), name="ping"),
+    path(
+        "msisdn_info/<str:msisdn>/",
+        views.MsisdnInfo.as_view(),
+        name="misisdn_info",
+    ),
+    path("get_countries/", views.GetCountries.as_view(), name="get_countries"),
+    path(
+        "get_operators/<int:country_id>/",
+        views.GetOperators.as_view(),
+        name="get_operators",
+    ),
+    path(
+        "get_products/<int:operator_id>/",
+        views.GetProducts.as_view(),
+        name="get_products",
+    ),
 ]

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -20,7 +20,7 @@ class TransferToClient:
             data[key] = value
         return data
 
-    def _make_transferto_request(self, action, url=None, **kwargs):
+    def _make_transferto_request(self, action, **kwargs):
         """
         Returns a dict with response from the TransferTo API
 
@@ -31,9 +31,7 @@ class TransferToClient:
             (self.login + self.token + key).encode("UTF-8")
         ).hexdigest()
         data = dict(login=self.login, key=key, md5=md5, action=action, **kwargs)
-        if url is None:
-            url = self.url
-        response = requests.post(url, data=data)
+        response = requests.post(self.url, data=data)
         return self._convert_response_body(response.content)
 
     def ping(self):

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -1,0 +1,83 @@
+import requests
+import time
+import hashlib
+
+
+class TransferToClient:
+    def __init__(self, login, token):
+        self.login = login
+        self.token = token
+        self.url = "https://airtime.transferto.com/cgi-bin/shop/topup"
+
+    def _convert_response_body(self, body_text):
+        """
+        Returns a dict of the airtime API body response
+        """
+        lines = body_text.decode("utf8").strip().split("\r\n")
+        data = {}
+        for line in lines:
+            [key, value] = line.split("=")
+            data[key] = value
+        return data
+
+    def _make_transferto_request(self, action, url=None, **kwargs):
+        """
+        Returns a dict with response from the TransferTo API
+
+        Reduces the boilerplate for constructing TransferTo requests
+        """
+        key = str(int(1000000 * time.time()))
+        md5 = hashlib.md5(
+            (self.login + self.token + key).encode("UTF-8")
+        ).hexdigest()
+        data = dict(login=self.login, key=key, md5=md5, action=action, **kwargs)
+        if url is None:
+            url = self.url
+        response = requests.post(url, data=data)
+        return self._convert_response_body(response.content)
+
+    def ping(self):
+        """
+        Check API status
+        """
+        return self._make_transferto_request("ping")
+
+    def get_misisdn_info(self, msisdn):
+        """
+        Returns dict with information for a given MSISDN
+        """
+        action = "msisdn_info"
+        return self._make_transferto_request(action, destination_msisdn=msisdn)
+
+    def get_countries(self):
+        """
+        Returns list of countries offered to your TransferTo account
+        """
+        return self._make_transferto_request(
+            action="pricelist", info_type="countries"
+        )
+
+    def get_operators(self, country_id):
+        """
+        Return the list of operators offered to your account, for a specific country
+
+        @param:integer country_id
+        """
+        if type(country_id) != int:
+            raise TypeError("arg must be an int")
+        else:
+            return self._make_transferto_request(
+                action="pricelist", info_type="country", content=country_id
+            )
+
+    def get_operator_products(self, operator_id):
+        """
+        Returns the list of denomination including wholesale and retail prices offered to your account,
+        for a specific operator
+        """
+        if type(operator_id) != int:
+            raise TypeError("arg must be an int")
+        else:
+            return self._make_transferto_request(
+                action="pricelist", info_type="operator", content=operator_id
+            )

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -49,6 +49,13 @@ class TransferToClient:
         action = "msisdn_info"
         return self._make_transferto_request(action, destination_msisdn=msisdn)
 
+    def reserve_id(self):
+        """
+        Returns dict with information for a given MSISDN
+        """
+        action = "reserve_id"
+        return self._make_transferto_request(action)
+
     def get_countries(self):
         """
         Returns list of countries offered to your TransferTo account

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -40,21 +40,21 @@ class TransferToClient:
         """
         Check API status
         """
-        return self._make_transferto_request("ping")
+        return self._make_transferto_request(action="ping")
 
     def get_misisdn_info(self, msisdn):
         """
         Returns dict with information for a given MSISDN
         """
-        action = "msisdn_info"
-        return self._make_transferto_request(action, destination_msisdn=msisdn)
+        return self._make_transferto_request(
+            action="msisdn_info", destination_msisdn=msisdn
+        )
 
     def reserve_id(self):
         """
-        Returns dict with information for a given MSISDN
+        Returns dict with id for future transaction
         """
-        action = "reserve_id"
-        return self._make_transferto_request(action)
+        return self._make_transferto_request(action="reserve_id")
 
     def get_countries(self):
         """

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -88,3 +88,32 @@ class TransferToClient:
             return self._make_transferto_request(
                 action="pricelist", info_type="operator", content=operator_id
             )
+
+    def make_topup(
+        self,
+        msisdn,
+        product,
+        source_msisdn=None,
+        source_name=None,
+        reserve_id=None,
+    ):
+        """
+        Returns the list of denomination including wholesale and retail prices offered to your account,
+        for a specific operator
+        """
+        if source_msisdn is None and source_name is None:
+            raise Exception("source_msisdn and source_name cannot both be None")
+        if type(product) != int:
+            raise TypeError("product arg must be an int")
+
+        keyword_args = {
+            "action": "topup",
+            "destination_msisdn": msisdn,
+            "msisdn": source_msisdn or source_name,
+            "product": product,
+        }
+
+        if reserve_id:
+            keyword_args["reserve_id"] = reserve_id
+
+        return self._make_transferto_request(**keyword_args)

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -22,6 +22,14 @@ class MsisdnInfo(APIView):
         return JsonResponse(client.get_misisdn_info(msisdn))
 
 
+class ReserveId(APIView):
+    def get(self, request):
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.reserve_id())
+
+
 class GetCountries(APIView):
     def get(self, request):
         client = TransferToClient(

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -1,3 +1,7 @@
-from django.shortcuts import render
+from django.http import JsonResponse
+from rest_framework.views import APIView
 
-# Create your views here.
+
+class GetProducts(APIView):
+    def get(self, request):
+        return JsonResponse({"status": "okay"})

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -1,7 +1,46 @@
+from django.conf import settings
 from django.http import JsonResponse
 from rest_framework.views import APIView
 
+from .utils import TransferToClient
+
+
+class Ping(APIView):
+    def get(self, request):
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.ping())
+
+
+class MsisdnInfo(APIView):
+    def get(self, request, msisdn):
+        # TODO: check msisdn
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.get_misisdn_info(msisdn))
+
+
+class GetCountries(APIView):
+    def get(self, request):
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.get_countries())
+
+
+class GetOperators(APIView):
+    def get(self, request, country_id):
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.get_operators(country_id))
+
 
 class GetProducts(APIView):
-    def get(self, request):
-        return JsonResponse({"status": "okay"})
+    def get(self, request, operator_id):
+        client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        return JsonResponse(client.get_operator_products(operator_id))


### PR DESCRIPTION
This PR does a number of things (apologies for its heftiness):
- adds `rp_transferto` django application
- adds transferto API client (to split into its own lib at some point in the future)
- creates a protected API endpoint to simplify getting info from TransferTo

extra add-ons that should have been in their own PR:
- docker-compose file
- updated `.gitignore` file

Things this PR does _not_ do, but will in a future date
- integrate with the Org model for rapidpro integration
- store transferto credentials in the DB rather than as env variables
- add long running celery tasks to handle multiple transferto interaction and rapidpro updates
- sphinx documentation and explanatory docs