### PR TITLE
Field choices, split only on first comma

### DIFF
--- a/rp_redcap/tasks.py
+++ b/rp_redcap/tasks.py
@@ -49,7 +49,7 @@ class ProjectCheck(Task):
             if field["field_name"] == field_name:
                 choices.update(
                     dict(
-                        item.split(", ")
+                        item.split(", ", 1)
                         for item in field[
                             "select_choices_or_calculations"
                         ].split(" | ")

--- a/rp_redcap/tests/test_tasks.py
+++ b/rp_redcap/tests/test_tasks.py
@@ -543,3 +543,20 @@ class SurveyCheckTaskTests(RedcapBaseTestCase, TestCase):
         project_check(str(self.project.id))
 
         self.assertEqual(len(responses.calls), 0)
+
+    def test_get_choices(self):
+
+        metadata = [
+            {
+                "field_name": "role",
+                "field_label": "Role",
+                "required_field": "y",
+                "branching_logic": "",
+                "select_choices_or_calculations": "0, Lead (Investigator, Detective) | 1, Investigator",  # noqa
+            }
+        ]
+
+        roles = project_check.get_choices(metadata, "role")
+
+        self.assertEqual(roles["0"], "Lead (Investigator, Detective)")
+        self.assertEqual(roles["1"], "Investigator")


### PR DESCRIPTION
Sometimes there is a comma in the choice text, this change will ignore it.