### PR TITLE
Clean message before sending to engage

### DIFF
--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -8,3 +8,12 @@ class UtilsTests(TestCase):
     def test_get_today(self):
 
         self.assertEqual(utils.get_today(), timezone.now().date())
+
+    def test_clean_message(self):
+
+        self.assertEqual(
+            utils.clean_message(
+                "No new lines\nNo tabs\t              No huge spaces"
+            ),
+            "No new lines No tabs No huge spaces",
+        )

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -89,48 +89,6 @@ class SurveyCheckViewTests(APITestCase):
             },
         )
 
-    @responses.activate
-    def test_send_wa_template_message_invalid_chars(self):
-
-        org = Organization.objects.create(
-            name="Test Organization",
-            url="http://localhost:8002/",
-            token="REPLACEME",
-            engage_url="http://localhost:8005",
-            engage_token="REPLACEME",
-        )
-
-        responses.add(
-            responses.POST,
-            "http://localhost:8005/v1/messages",
-            json={
-                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
-                "meta": {"api_status": "stable", "version": "2.19.4"},
-            },
-            status=201,
-            match_querystring=True,
-        )
-
-        params = {
-            "org_id": org.id,
-            "wa_id": "1234",
-            "namespace": "test.namespace",
-            "element_name": "el",
-            "message": "No new lines\nNo tabs\t              No huge spaces",
-        }
-
-        url = "{}?{}".format(reverse("send_template"), urlencode(params))
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        request_body = json.loads(responses.calls[0].request.body)
-
-        self.assertEqual(
-            request_body["hsm"]["localizable_params"][0]["default"],
-            "No new lines No tabs No huge spaces",
-        )
-
     def test_send_wa_template_message_no_org(self):
         params = {
             "org_id": "2",

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -74,6 +74,63 @@ class SurveyCheckViewTests(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
+        request_body = json.loads(responses.calls[0].request.body)
+        self.assertEqual(
+            request_body,
+            {
+                "to": "1234",
+                "type": "hsm",
+                "hsm": {
+                    "namespace": "test.namespace",
+                    "element_name": "el",
+                    "language": {"policy": "fallback", "code": "en_US"},
+                    "localizable_params": [{"default": "hey!"}],
+                },
+            },
+        )
+
+    @responses.activate
+    def test_send_wa_template_message_invalid_chars(self):
+
+        org = Organization.objects.create(
+            name="Test Organization",
+            url="http://localhost:8002/",
+            token="REPLACEME",
+            engage_url="http://localhost:8005",
+            engage_token="REPLACEME",
+        )
+
+        responses.add(
+            responses.POST,
+            "http://localhost:8005/v1/messages",
+            json={
+                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
+                "meta": {"api_status": "stable", "version": "2.19.4"},
+            },
+            status=201,
+            match_querystring=True,
+        )
+
+        params = {
+            "org_id": org.id,
+            "wa_id": "1234",
+            "namespace": "test.namespace",
+            "element_name": "el",
+            "message": "No new lines\nNo tabs\t              No huge spaces",
+        }
+
+        url = "{}?{}".format(reverse("send_template"), urlencode(params))
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        request_body = json.loads(responses.calls[0].request.body)
+
+        self.assertEqual(
+            request_body["hsm"]["localizable_params"][0]["default"],
+            "No new lines No tabs No huge spaces",
+        )
+
     def test_send_wa_template_message_no_org(self):
         params = {
             "org_id": "2",

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -7,3 +7,7 @@ def get_today():
 
 def get_current_week_number():
     return int(get_today().strftime("%W"))
+
+
+def clean_message(message):
+    return " ".join(message.replace("\n", " ").replace("\t", " ").split())

--- a/sidekick/views.py
+++ b/sidekick/views.py
@@ -6,6 +6,7 @@ from django.http import JsonResponse
 from rest_framework import status
 
 from .models import Organization
+from .utils import clean_message
 
 
 def health(request):
@@ -39,9 +40,7 @@ def send_wa_template_message(request):
     wa_id = data["wa_id"]
     namespace = data["namespace"]
     element_name = data["element_name"]
-    message = " ".join(
-        data["message"].replace("\n", " ").replace("\t", " ").split()
-    )
+    message = clean_message(data["message"])
 
     try:
         org = Organization.objects.get(id=org_id)

--- a/sidekick/views.py
+++ b/sidekick/views.py
@@ -39,7 +39,9 @@ def send_wa_template_message(request):
     wa_id = data["wa_id"]
     namespace = data["namespace"]
     element_name = data["element_name"]
-    message = data["message"]
+    message = " ".join(
+        data["message"].replace("\n", " ").replace("\t", " ").split()
+    )
 
     try:
         org = Organization.objects.get(id=org_id)


### PR DESCRIPTION
Messages sent using the `hsm` endpoint cannot have new-line/tab characters or more than 4 consecutive spaces, this makes sure we remove them before sending.