### PR TITLE
Add metadata to complete check

### DIFF
--- a/rp_redcap/tasks.py
+++ b/rp_redcap/tasks.py
@@ -9,14 +9,13 @@ from sidekick import utils
 from .models import Contact, Project, SurveyAnswer, PatientRecord, PatientValue
 
 
-class ProjectCheck(Task):
-    """Task to look for incomplete surveys in a Project."""
+class BaseTask(Task):
+    def get_metadata(self, redcap_client, survey_name=None):
+        forms = []
+        if survey_name:
+            forms.append(survey_name)
 
-    name = "rp_redcap.tasks.project_check"
-    log = get_task_logger(__name__)
-
-    def get_metadata(self, survey_name, redcap_client):
-        return redcap_client.export_metadata(forms=[survey_name])
+        return redcap_client.export_metadata(forms=forms)
 
     def get_required_fields(self, metadata):
 
@@ -39,6 +38,13 @@ class ProjectCheck(Task):
                 }
 
         return required_fields
+
+
+class ProjectCheck(BaseTask):
+    """Task to look for incomplete surveys in a Project."""
+
+    name = "rp_redcap.tasks.project_check"
+    log = get_task_logger(__name__)
 
     def get_records(self, survey_name, redcap_client):
         return redcap_client.export_records(
@@ -132,7 +138,7 @@ class ProjectCheck(Task):
         for survey in project.surveys.all().order_by("sequence"):
 
             records = self.get_records(survey.name, redcap_client)
-            metadata = self.get_metadata(survey.name, redcap_client)
+            metadata = self.get_metadata(redcap_client, survey.name)
 
             required_fields = self.get_required_fields(metadata)
             ignore_fields = survey.get_ignore_fields()
@@ -203,7 +209,7 @@ class ProjectCheck(Task):
 project_check = ProjectCheck()
 
 
-class PatientDataCheck(Task):
+class PatientDataCheck(BaseTask):
     """Remind hospital leads about missing patient data."""
 
     name = "rp_redcap.tasks.patient_data_check"
@@ -272,7 +278,7 @@ class PatientDataCheck(Task):
                         obj.value = value
                         obj.save()
 
-    def refresh_historical_data(self, project, patient_client):
+    def refresh_historical_data(self, project, patient_client, required_fields):
         record_ids = []
 
         for patient_record in PatientRecord.objects.filter(
@@ -289,12 +295,12 @@ class PatientDataCheck(Task):
             )
 
             patient_records = self.check_patients_status(
-                project, patient_records
+                project, patient_records, required_fields
             )
 
             self.save_patient_records(project, patient_records)
 
-    def check_patients_status(self, project, patients):
+    def check_patients_status(self, project, patients, required_fields):
 
         pre_op_fields = project.pre_operation_fields.split(",")
         post_op_fields = project.post_operation_fields.split(",")
@@ -303,19 +309,28 @@ class PatientDataCheck(Task):
             patient["pre_operation_status"] = PatientRecord.COMPLETE_STATUS
             patient["post_operation_status"] = PatientRecord.COMPLETE_STATUS
             for field, value in patient.items():
-                if value == "" and field in pre_op_fields:
+                if (
+                    value == ""
+                    and field in pre_op_fields
+                    and field in required_fields
+                    and eval(required_fields[field]["condition"])
+                ):
                     patient[
                         "pre_operation_status"
                     ] = PatientRecord.INCOMPLETE_STATUS
-                if value == "" and field in post_op_fields:
+                if (
+                    value == ""
+                    and field in post_op_fields
+                    and field in required_fields
+                    and eval(required_fields[field]["condition"])
+                ):
                     patient[
                         "post_operation_status"
                     ] = PatientRecord.INCOMPLETE_STATUS
-
         return patients
 
     def get_reminders_for_date(
-        self, date, project, screening_client, patient_client
+        self, date, project, screening_client, patient_client, required_fields
     ):
         messages = defaultdict(lambda: defaultdict(list))
         if date.weekday() > 4:
@@ -334,7 +349,9 @@ class PatientDataCheck(Task):
             patient_client, "asos2_crf", "[date_surg] = '{}'".format(date)
         )
 
-        patient_records = self.check_patients_status(project, patient_records)
+        patient_records = self.check_patients_status(
+            project, patient_records, required_fields
+        )
 
         for hospital in project.hospitals.all():
 
@@ -428,13 +445,16 @@ class PatientDataCheck(Task):
         patient_client = project.get_redcap_crf_client()
         rapidpro_client = project.org.get_rapidpro_client()
 
+        metadata = self.get_metadata(patient_client)
+        required_fields = self.get_required_fields(metadata)
+
         messages = defaultdict(lambda: defaultdict(list))
 
         for day in range(0, settings.REDCAP_HISTORICAL_DAYS):
             date = utils.get_today() - datetime.timedelta(days=day + 1)
 
             new_messages = self.get_reminders_for_date(
-                date, project, screening_client, patient_client
+                date, project, screening_client, patient_client, required_fields
             )
 
             for hospital, date_messages in new_messages.items():
@@ -443,7 +463,7 @@ class PatientDataCheck(Task):
 
         self.send_reminders(messages, rapidpro_client, project.org)
 
-        self.refresh_historical_data(project, patient_client)
+        self.refresh_historical_data(project, patient_client, required_fields)
 
 
 patient_data_check = PatientDataCheck()

--- a/rp_redcap/tasks.py
+++ b/rp_redcap/tasks.py
@@ -318,6 +318,8 @@ class PatientDataCheck(Task):
         self, date, project, screening_client, patient_client
     ):
         messages = defaultdict(lambda: defaultdict(list))
+        if date.weekday() > 4:
+            return messages
 
         screening_date = date - datetime.timedelta(days=date.weekday())
         screening_field = "day{}".format(date.weekday() + 1)

--- a/rp_redcap/tests/test_tasks.py
+++ b/rp_redcap/tests/test_tasks.py
@@ -1025,6 +1025,21 @@ class SurveyCheckPatientTaskTests(RedcapBaseTestCase, TestCase):
             messages[hospital2][date], ["Not all patients captured.(1/2)"]
         )
 
+    @patch("rp_redcap.tasks.patient_data_check.get_redcap_records")
+    def test_get_reminders_patients_weekend(self, mock_get_redcap_records):
+        hospital = self.create_hospital()
+
+        date = datetime.date(2018, 6, 17)
+        screening_client = MockRedCapPatients()
+        patient_client = MockRedCapPatients()
+
+        messages = patient_data_check.get_reminders_for_date(
+            date, self.project, screening_client, patient_client
+        )
+
+        self.assertEqual(messages[hospital][date], [])
+        mock_get_redcap_records.assert_not_called()
+
     @responses.activate
     @patch("sidekick.utils.update_rapidpro_whatsapp_urn")
     def test_send_reminders(self, mock_update_rapidpro_whatsapp_urn):


### PR DESCRIPTION
I added the metadata check to see if record is complete, so the field must be required in the metadata and in the pre/post operation field list to change the status.

The two functions to get the metadata are used in both tasks, I made a base task to not repeat any code.