### PR TITLE
Install pycap from github commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       install:
         - pip install -r requirements.txt --use-wheel
         - pip install -r requirements-dev.txt --use-wheel
+        # temporary until there is a new PyCap Release
+        - pip install git+git://github.com/redcap-tools/PyCap.git@d9d3dea68640920eefb5d5d095cc62d2968c202d   # yamllint disable-line
         - pip install codecov
       before_script:
         - psql -U postgres -c "CREATE DATABASE rp_sidekick;"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ VERSIONS
 
 Next Release
 ------------
+ * Install PyCap from Github commit until they make a release(temporary)
 
 1.0.10
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ VERSIONS
 Next Release
 ------------
  * Install PyCap from Github commit until they make a release(temporary)
+ * Add Hospital and PatientRecord to admin site
 
 1.0.10
 ------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM praekeltfoundation/django-bootstrap:py3.6
 COPY . /app
 RUN pip install -e .
 
+# temporary untill there is a new PyCap Release
+RUN apt-get-install.sh git
+RUN pip install git+git://github.com/redcap-tools/PyCap.git@d9d3dea68640920eefb5d5d095cc62d2968c202d
+
 ENV DJANGO_SETTINGS_MODULE "config.settings.production"
 RUN SECRET_KEY=placeholder ALLOWED_HOSTS=placeholder python manage.py collectstatic --noinput
 CMD ["config.wsgi:application"]

--- a/rp_redcap/admin.py
+++ b/rp_redcap/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
-from .models import Survey, Project, Contact
+from .models import Survey, Project, Contact, Hospital, PatientRecord
 
 admin.site.register(Project)
 admin.site.register(Survey)
 admin.site.register(Contact)
+admin.site.register(Hospital)
+admin.site.register(PatientRecord)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         "django-extensions==2.1.0",
         "djangorestframework==3.8.2",
         "psycopg2==2.7.1",
-        "PyCap",
         "rapidpro-python==2.4",
         "redis==2.10.6",
         "whitenoise==3.3.1",


### PR DESCRIPTION
I made a change to PyCap which they haven't released yet. They suggested I install it from github until a new release is made.

I'm changing travis to also use github and all my local tests has been with this version.