### PR TITLE
Add purchase airtime task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ VERSIONS
 
 Next Release
 ------------
+* TransferTo: refactored task functionality into to take_action function - updates RapidPro fields and/or starts another flow
+* TransferTo: add endpoint which purchases airtime, then updates RapidPro state with new take_action function
 
 1.0.13
 ------------

--- a/docs/apps/transferto.md
+++ b/docs/apps/transferto.md
@@ -17,3 +17,8 @@ While RapidPro does provide an integration with TransferTo to release airtime, i
     - purchase a product for a particular msisdn
     - [optional] update a rapidpro contact's fields based on the response
     - [optional] start the participant on another rapidpro flow, once the task has been completed.
+
+- `BuyAirtimeTakeAction`: this endpoint allows the user to
+    - purchase airtime for a particular msisdn
+    - [optional] update a rapidpro contact's fields based on the response
+    - [optional] start the participant on another rapidpro flow, once the task has been completed.

--- a/rp_transferto/tasks.py
+++ b/rp_transferto/tasks.py
@@ -156,6 +156,7 @@ class BuyAirtimeTakeAction(Task):
         self,
         msisdn,
         airtime_amount,
+        from_string,
         user_uuid=None,
         values_to_update={},
         flow_start=None,
@@ -176,7 +177,9 @@ class BuyAirtimeTakeAction(Task):
         transferto_client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        topup_result = transferto_client.make_topup(msisdn, airtime_amount)
+        topup_result = transferto_client.make_topup(
+            msisdn, airtime_amount, from_string
+        )
 
         log.info(json.dumps(topup_result, indent=2))
 

--- a/rp_transferto/tasks.py
+++ b/rp_transferto/tasks.py
@@ -141,25 +141,12 @@ class BuyProductTakeAction(Task):
         log.info(json.dumps(purchase_result, indent=2))
 
         if user_uuid:
-            # update rapidpro with info
-            rapidpro_client = TembaClient(
-                settings.RAPIDPRO_URL, settings.RAPIDPRO_TOKEN
+            take_action(
+                user_uuid,
+                values_to_update=values_to_update,
+                call_result=purchase_result,
+                flow_start=flow_start,
             )
-
-            if values_to_update:
-                fields = {}
-                for (
-                    rapidpro_field,
-                    transferto_field,
-                ) in values_to_update.items():
-                    fields[rapidpro_field] = purchase_result[transferto_field]
-
-                rapidpro_client.update_contact(user_uuid, fields=fields)
-
-            if flow_start:
-                rapidpro_client.create_flow_start(
-                    flow_start, contacts=[user_uuid], restart_participants=True
-                )
 
 
 topup_data = TopupData()

--- a/rp_transferto/tasks.py
+++ b/rp_transferto/tasks.py
@@ -149,5 +149,46 @@ class BuyProductTakeAction(Task):
             )
 
 
+class BuyAirtimeTakeAction(Task):
+    name = "rp_transferto.tasks.buy_airtime_take_action"
+
+    def run(
+        self,
+        msisdn,
+        airtime_amount,
+        user_uuid=None,
+        values_to_update={},
+        flow_start=None,
+    ):
+        log.info(
+            json.dumps(
+                dict(
+                    name=self.name,
+                    msisdn=msisdn,
+                    airtime_amount=airtime_amount,
+                    user_uuid=user_uuid,
+                    values_to_update=values_to_update,
+                    flow_start=flow_start,
+                ),
+                indent=2,
+            )
+        )
+        transferto_client = TransferToClient(
+            settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
+        )
+        topup_result = transferto_client.make_topup(msisdn, airtime_amount)
+
+        log.info(json.dumps(topup_result, indent=2))
+
+        if user_uuid:
+            take_action(
+                user_uuid,
+                values_to_update=values_to_update,
+                call_result=topup_result,
+                flow_start=flow_start,
+            )
+
+
 topup_data = TopupData()
 buy_product_take_action = BuyProductTakeAction()
+buy_airtime_take_action = BuyAirtimeTakeAction()

--- a/rp_transferto/tests/test_tasks.py
+++ b/rp_transferto/tests/test_tasks.py
@@ -268,10 +268,10 @@ class TestBuyAirtimeTakeAction(TestCase):
 
         msisdn = "+27820000001"
         product_id = 111
-        buy_airtime_take_action(msisdn, product_id)
+        from_string = "bob"
+        buy_airtime_take_action(msisdn, product_id, from_string)
 
-        self.assertTrue(fake_make_topup.called)
-        fake_make_topup.assert_called_with(msisdn, product_id)
+        fake_make_topup.assert_called_with(msisdn, product_id, from_string)
         self.assertFalse(fake_take_action.called)
 
     @patch("rp_transferto.tasks.take_action")
@@ -285,6 +285,7 @@ class TestBuyAirtimeTakeAction(TestCase):
 
         msisdn = "+27820000001"
         product_id = 333
+        from_string = "bob"
         user_uuid = "3333-abc"
         values_to_update = {
             "rp_0001_01_transferto_status": "status",
@@ -295,11 +296,12 @@ class TestBuyAirtimeTakeAction(TestCase):
         buy_airtime_take_action(
             msisdn,
             product_id,
+            from_string,
             user_uuid=user_uuid,
             values_to_update=values_to_update,
         )
 
-        fake_make_topup.assert_called_with(msisdn, product_id)
+        fake_make_topup.assert_called_with(msisdn, product_id, from_string)
         self.assertTrue(fake_take_action.called)
         fake_take_action.assert_called_with(
             user_uuid,
@@ -319,14 +321,19 @@ class TestBuyAirtimeTakeAction(TestCase):
 
         msisdn = "+27820006000"
         product_id = 444
+        from_string = "bob"
         user_uuid = "4444-abc"
         flow_uuid = "123412341234"
 
         buy_airtime_take_action(
-            msisdn, product_id, user_uuid=user_uuid, flow_start=flow_uuid
+            msisdn,
+            product_id,
+            from_string,
+            user_uuid=user_uuid,
+            flow_start=flow_uuid,
         )
 
-        fake_make_topup.assert_called_with(msisdn, product_id)
+        fake_make_topup.assert_called_with(msisdn, product_id, from_string)
         self.assertTrue(fake_take_action.called)
         fake_take_action.assert_called_with(
             user_uuid,

--- a/rp_transferto/tests/test_utils.py
+++ b/rp_transferto/tests/test_utils.py
@@ -104,17 +104,9 @@ class TestTransferToClient(TestCase):
             self.client.get_operator_airtime_products("not an int")
         self.assertEqual(exception_info.value.__str__(), "arg must be an int")
 
-    def test_make_topup_throws_exception_source_variables(self):
-        with raises(Exception) as exception_info:
-            self.client.make_topup("fake_msisdn", 10)
-        self.assertEqual(
-            exception_info.value.__str__(),
-            "source_msisdn and source_name cannot both be None",
-        )
-
     def test_make_topup_throws_exception_product_must_be_int(self):
         with raises(TypeError) as exception_info:
-            self.client.make_topup("fake_msisdn", "10", source_name="test_name")
+            self.client.make_topup("fake_msisdn", "10", from_string="test_name")
         self.assertEqual(
             exception_info.value.__str__(), "product arg must be an int"
         )
@@ -122,7 +114,7 @@ class TestTransferToClient(TestCase):
     def test_make_topup_1(self):
         client = TransferToClient("fake_login", "fake_token")
         with patch.object(client, "_make_transferto_request") as mock:
-            client.make_topup("+27820000001", 10, source_msisdn="+27820000002")
+            client.make_topup("+27820000001", 10, from_string="+27820000002")
 
         mock.assert_called_once_with(
             action="topup",
@@ -134,7 +126,7 @@ class TestTransferToClient(TestCase):
     def test_make_topup_2(self):
         client = TransferToClient("fake_login", "fake_token")
         with patch.object(client, "_make_transferto_request") as mock:
-            client.make_topup("+27820000001", 10, source_name="john")
+            client.make_topup("+27820000001", 10, from_string="john")
 
         mock.assert_called_once_with(
             action="topup",
@@ -147,10 +139,7 @@ class TestTransferToClient(TestCase):
         client = TransferToClient("fake_login", "fake_token")
         with patch.object(client, "_make_transferto_request") as mock:
             client.make_topup(
-                "+27820000001",
-                10,
-                source_msisdn="+27820000002",
-                reserve_id=1234,
+                "+27820000001", 10, from_string="+27820000002", reserve_id=1234
             )
 
         mock.assert_called_once_with(

--- a/rp_transferto/tests/test_views.py
+++ b/rp_transferto/tests/test_views.py
@@ -320,12 +320,17 @@ class TestTransferToViews(APITestCase):
     ):
         msisdn = "+27820006000"
         airtime_amount = 444
+        from_string = "bob"
         self.assertFalse(fake_buy_airtime_take_action.called)
 
         response = self.api_client.get(
             reverse(
                 "buy_airtime_take_action",
-                kwargs={"msisdn": msisdn, "airtime_amount": airtime_amount},
+                kwargs={
+                    "msisdn": msisdn,
+                    "airtime_amount": airtime_amount,
+                    "from_string": from_string,
+                },
             )
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -336,6 +341,7 @@ class TestTransferToViews(APITestCase):
         fake_buy_airtime_take_action.assert_called_with(
             clean_msisdn(msisdn),
             airtime_amount,
+            from_string,
             flow_start=False,
             user_uuid=False,
             values_to_update={},
@@ -347,6 +353,7 @@ class TestTransferToViews(APITestCase):
     ):
         msisdn = "+27820006000"
         airtime_amount = 444
+        from_string = "bob"
         user_uuid = "3333-abc"
         values_to_update = {
             "rp_0001_01_transferto_status": "status",
@@ -363,7 +370,11 @@ class TestTransferToViews(APITestCase):
         ).format(
             base_url=reverse(
                 "buy_airtime_take_action",
-                kwargs={"msisdn": msisdn, "airtime_amount": airtime_amount},
+                kwargs={
+                    "msisdn": msisdn,
+                    "airtime_amount": airtime_amount,
+                    "from_string": from_string,
+                },
             ),
             user_uuid=user_uuid,
         )
@@ -378,6 +389,7 @@ class TestTransferToViews(APITestCase):
         fake_buy_airtime_take_action.assert_called_with(
             clean_msisdn(msisdn),
             airtime_amount,
+            from_string,
             flow_start=False,
             user_uuid=user_uuid,
             values_to_update=values_to_update,
@@ -389,6 +401,7 @@ class TestTransferToViews(APITestCase):
     ):
         msisdn = "+27820006000"
         airtime_amount = 444
+        from_string = "bob"
         user_uuid = "3333-abc"
         flow_uuid = "123412341234"
 
@@ -397,7 +410,11 @@ class TestTransferToViews(APITestCase):
         ).format(
             base_url=reverse(
                 "buy_airtime_take_action",
-                kwargs={"msisdn": msisdn, "airtime_amount": airtime_amount},
+                kwargs={
+                    "msisdn": msisdn,
+                    "airtime_amount": airtime_amount,
+                    "from_string": from_string,
+                },
             ),
             user_uuid=user_uuid,
             flow_uuid=flow_uuid,
@@ -413,6 +430,7 @@ class TestTransferToViews(APITestCase):
         fake_buy_airtime_take_action.assert_called_with(
             clean_msisdn(msisdn),
             airtime_amount,
+            from_string,
             flow_start=flow_uuid,
             user_uuid=user_uuid,
             values_to_update={},

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
         name="buy_product_take_action",
     ),
     path(
-        "buy/airtime/<int:airtime_amount>/<str:msisdn>/",
+        "buy/airtime/<int:airtime_amount>/<str:msisdn>/from/<str:from_string>/",
         views.BuyAirtimeTakeAction.as_view(),
         name="buy_airtime_take_action",
     ),

--- a/rp_transferto/urls.py
+++ b/rp_transferto/urls.py
@@ -37,4 +37,9 @@ urlpatterns = [
         views.BuyProductTakeAction.as_view(),
         name="buy_product_take_action",
     ),
+    path(
+        "buy/airtime/<int:airtime_amount>/<str:msisdn>/",
+        views.BuyAirtimeTakeAction.as_view(),
+        name="buy_airtime_take_action",
+    ),
 ]

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -98,8 +98,7 @@ class TransferToClient:
         reserve_id=None,
     ):
         """
-        Returns the list of denomination including wholesale and retail prices offered to your account,
-        for a specific operator
+        Purchase amount for a specifc number
         """
         if source_msisdn is None and source_name is None:
             raise Exception("source_msisdn and source_name cannot both be None")

--- a/rp_transferto/utils.py
+++ b/rp_transferto/utils.py
@@ -89,26 +89,23 @@ class TransferToClient:
                 action="pricelist", info_type="operator", content=operator_id
             )
 
-    def make_topup(
-        self,
-        msisdn,
-        product,
-        source_msisdn=None,
-        source_name=None,
-        reserve_id=None,
-    ):
+    def make_topup(self, msisdn, product, from_string, reserve_id=None):
         """
-        Purchase amount for a specifc number
+        Make
+
+        :param str msisdn: the msisdn that should receive the data
+        :param int product: integer representing amount of airtime to send to msisdn
+        :param str from_string: either in msisdn form or a name. e.g. "+6012345678" or "John" are all valid.
+        :param str reserve_id: [optional] see transferto documentation for more details about reserve id
+        :return: dict of transaction response from transferto
         """
-        if source_msisdn is None and source_name is None:
-            raise Exception("source_msisdn and source_name cannot both be None")
         if type(product) != int:
             raise TypeError("product arg must be an int")
 
         keyword_args = {
             "action": "topup",
             "destination_msisdn": msisdn,
-            "msisdn": source_msisdn or source_name,
+            "msisdn": from_string,
             "product": product,
         }
 

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -6,7 +6,7 @@ from sidekick.utils import clean_msisdn
 
 from .models import MsisdnInformation
 from .utils import TransferToClient, TransferToClient2
-from .tasks import topup_data, buy_product_take_action
+from .tasks import topup_data, buy_product_take_action, buy_airtime_take_action
 
 
 class Ping(APIView):
@@ -131,3 +131,28 @@ class BuyProductTakeAction(APIView):
             flow_start=flow_start,
         )
         return JsonResponse({"info_txt": "buy_product_take_action"})
+
+
+class BuyAirtimeTakeAction(APIView):
+    def get(self, request, airtime_amount, msisdn, *args, **kwargs):
+        flow_uuid_key = "flow_uuid"
+        user_uuid_key = "user_uuid"
+        data = dict(request.GET.dict())
+
+        flow_start = request.GET.get(flow_uuid_key, False)
+        if flow_start:
+            del data[flow_uuid_key]
+        user_uuid = request.GET.get(user_uuid_key, False)
+        if user_uuid:
+            del data[user_uuid_key]
+        # remaining variables will be coerced from key:value mapping
+        # which represents variable on rapidpro to update: variable from response
+
+        buy_airtime_take_action.delay(
+            clean_msisdn(msisdn),
+            airtime_amount,
+            user_uuid=user_uuid,
+            values_to_update=data,
+            flow_start=flow_start,
+        )
+        return JsonResponse({"info_txt": "buy_airtime_take_action"})

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -134,7 +134,9 @@ class BuyProductTakeAction(APIView):
 
 
 class BuyAirtimeTakeAction(APIView):
-    def get(self, request, airtime_amount, msisdn, *args, **kwargs):
+    def get(
+        self, request, airtime_amount, msisdn, from_string, *args, **kwargs
+    ):
         flow_uuid_key = "flow_uuid"
         user_uuid_key = "user_uuid"
         data = dict(request.GET.dict())
@@ -151,6 +153,7 @@ class BuyAirtimeTakeAction(APIView):
         buy_airtime_take_action.delay(
             clean_msisdn(msisdn),
             airtime_amount,
+            from_string,
             user_uuid=user_uuid,
             values_to_update=data,
             flow_start=flow_start,


### PR DESCRIPTION
TransferTo differentiates between 'products' (data bundles) and 'airtime'. This adds a similar task to the previous PR, and differs only in what is being purchased.