### PR TITLE
[GPE-1099] handle number out of range

### DIFF
--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -32,7 +32,7 @@ class Ping(APIView):
         client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        return JsonResponse(client.ping())
+        return process_status_code(client.ping())
 
 
 class MsisdnInfo(APIView):
@@ -53,13 +53,14 @@ class MsisdnInfo(APIView):
             cleaned_msisdn = clean_msisdn(msisdn)
             info = client.get_misisdn_info(cleaned_msisdn)
             MsisdnInformation.objects.create(data=info, msisdn=cleaned_msisdn)
-            return JsonResponse(info)
-        cached_result = dict(
-            MsisdnInformation.objects.filter(msisdn=clean_msisdn(msisdn))
-            .latest()
-            .data
-        )
-        return JsonResponse(cached_result)
+        # get cached result
+        else:
+            info = dict(
+                MsisdnInformation.objects.filter(msisdn=clean_msisdn(msisdn))
+                .latest()
+                .data
+            )
+        return process_status_code(info)
 
 
 class ReserveId(APIView):
@@ -67,7 +68,7 @@ class ReserveId(APIView):
         client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        return JsonResponse(client.reserve_id())
+        return process_status_code(client.reserve_id())
 
 
 class GetCountries(APIView):
@@ -75,7 +76,7 @@ class GetCountries(APIView):
         client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        return JsonResponse(client.get_countries())
+        return process_status_code(client.get_countries())
 
 
 class GetOperators(APIView):
@@ -83,7 +84,7 @@ class GetOperators(APIView):
         client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        return JsonResponse(client.get_operators(country_id))
+        return process_status_code(client.get_operators(country_id))
 
 
 class GetOperatorAirtimeProducts(APIView):
@@ -91,7 +92,9 @@ class GetOperatorAirtimeProducts(APIView):
         client = TransferToClient(
             settings.TRANSFERTO_LOGIN, settings.TRANSFERTO_TOKEN
         )
-        return JsonResponse(client.get_operator_airtime_products(operator_id))
+        return process_status_code(
+            client.get_operator_airtime_products(operator_id)
+        )
 
 
 class GetOperatorProducts(APIView):

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -9,6 +9,24 @@ from .utils import TransferToClient, TransferToClient2
 from .tasks import topup_data, buy_product_take_action, buy_airtime_take_action
 
 
+def process_status_code(info):
+    """
+    returns a JsonResponse object with status updated to reflect info
+
+    For more detail on possible  TransferTo error codes, see
+    section "9.0 Standard API Errors" in https://shop.transferto.com/shop/v3/doc/TransferTo_API.pdf
+
+    @param info: dict containing key "error_code"
+    @returns: JsonResponse object with status updated to reflect "error_code"
+    @raises keyError: if "error_code" is not contained within info dict
+    """
+    error_code = info["error_code"]
+    if error_code not in ["0", 0]:
+        return JsonResponse(info, status=400)
+    # default to 200 status code
+    return JsonResponse(info)
+
+
 class Ping(APIView):
     def get(self, request, *args, **kwargs):
         client = TransferToClient(


### PR DESCRIPTION
This PR attempts to communicate any errors that we receive from TransferTo, by converting the default 200 status code from RP Sidekick to a generic 400 error, so that RapidPro can handle these 'Failure' scenarios.