### PR TITLE
Gpe 839 update hsm endpoint to accept localizable params

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ VERSIONS
 
 Next Release
 ------------
+* Sidekick: Fixed document structure and updated docs
+* Sidekick: updated WA templated message endpoint to accept multiple localizable params
 
 1.0.16
 ------------

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,8 @@ Rapidpro Sidekick
     :target: https://hub.docker.com/r/praekeltfoundation/rp-sidekick/tags/
     :alt: Docker Automated build
 
-Sidekick Django Web Application for Rapidpro - used to extend the functionality of Rapidpro.
+Sidekick is a Django application which provides additional functionality to RapidPro through RapidPro’s webhooks within flow, as well as using RP’s REST API to initiate flows, update contact fields etc.
+In some respects it functions much like setting up serverless functions to handle webhooks and return responses. However there are some additional benefits to using a Django application, primarily User authentication and management, as well as management of RapidPro Orgs.
 
 ------------------
 Local installation

--- a/docs/apps/sidekick.md
+++ b/docs/apps/sidekick.md
@@ -1,0 +1,15 @@
+# RP Sidekick
+The default Sidekick Module exists to provide shareable components across the various django applications, in particular the Org and User management. It also provides some miscellaneous functionality, in particular, the ability to send WhatsApp templated messages
+
+## WhatsApp Template Endpoint
+RapidPro does not yet provide first-class support for [WhatsApp templates](https://whatsapp.praekelt.org/docs/index.html#templated-messages), which means that they need to be sent via Sidekick, using a Webhook within RapidPro.
+
+### Required Parameters
+- `org_id`: this refers to the Organisation created within Sidekick. You can find this in the Admin page. There is a 1-to-1 mapping between the Org and a Turn account. Make sure you have added the necessary credentials to your Org.
+- `wa_id`: this will be the number of the individual you wish to contact. In RapidPro flows, this can be accessed using `@contact.whatsapp`
+- `element_name`: the name of the template that you are using. You will have created this when submitting it to WhatsApp for approval.
+- `namespace`: this argument will likely be fixed across your organisation. Check previous uses or check with whoever set up your WA account.
+
+### Localized Parameters
+Templated messages allow you to pass in variables. See the [Turn documentation](https://whatsapp.praekelt.org/docs/index.html#localizable-parameters-for-templated-messages) for more details. These can be passed to the endpoint by numbering your param arguments. e.g. `0=R25&1=24` will pass the parameters `R25` and `24` to the template, in that order.
+Note that this endpoint only orders the arguments, it does not attempt to skip over arguments. Thus `0=R25&1=24`, `1=R25&2=24` and `1=R25&99=24` will all be treated in an identical manner.

--- a/docs/apps/transferto.md
+++ b/docs/apps/transferto.md
@@ -2,6 +2,7 @@
 
 While RapidPro does provide an integration with TransferTo to release airtime, it does not allow for the remuneration of data. This application more faithfully represents the REST API that TransferTo makes available and abstracts away the authentication.
 
+### Synchronous Endpoints
 - `Ping`: check that our authentication to TransferTo is working
 - `MsisdnInfo`: get information about an MSISDN
 - `ReserveId`: get ID for a purchase transaction in the future
@@ -12,7 +13,9 @@ While RapidPro does provide an integration with TransferTo to release airtime, i
 - `GetCountryServices`: get services available in a particular country
 - `TopUpData`: an endpoint that immediately returns a 200 status code and then starts a Celery task to get information about a number, send the reward and update the necessary fields in RapidPro.
 
-## Sidekick Endpoints
+### Asyncronous Endpoints
+These endpoints will queue the request to TransferTo using celery. They will immediately respond with a 200 response code once the task is queued, preventing any timeouts on RapidPro. Use the `flow_uuid_key` arg to get the tasks to start the participant on a new flow, assuming that it works according to plan.
+
 - `BuyProductTakeAction`: this endpoint allows the user to
     - purchase a product for a particular msisdn
     - [optional] update a rapidpro contact's fields based on the response

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGELOG.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,24 +3,19 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-RapidPro Sidekick's documentation
-=================================
-
-.. include:: badges.rst
-
-Sidekick Django Web Application for Rapidpro - used to extend the functionality of Rapidpro.
+.. include:: ../README.rst
+.. include:: ../CHANGELOG.rst
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-   apps/redcap.rst
+   readme
+   apps/sidekick.md
+   apps/asos.rst
+   apps/redcap.md
+   apps/transferto.md
 
    ways-of-working.md
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   changelog

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../README.rst

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -10,9 +10,33 @@ from rest_framework.test import APITestCase, APIClient
 from ..models import Organization
 
 
-class SurveyCheckViewTests(APITestCase):
+class SidekickViewTests(APITestCase):
     def setUp(self):
         self.client = APIClient()
+
+    def add_whatsapp_messages_200_response(self, responses):
+        """
+        Keep things DRY by reusing this snippet when testing WA response
+        """
+        responses.add(
+            responses.POST,
+            "http://localhost:8005/v1/messages",
+            json={
+                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
+                "meta": {"api_status": "stable", "version": "2.19.4"},
+            },
+            status=201,
+            match_querystring=True,
+        )
+
+    def mk_org(self):
+        return Organization.objects.create(
+            name="Test Organization",
+            url="http://localhost:8002/",
+            token="REPLACEME",
+            engage_url="http://localhost:8005",
+            engage_token="REPLACEME",
+        )
 
     def test_health_endpoint(self):
         response = self.client.get(reverse("health"))
@@ -40,33 +64,15 @@ class SurveyCheckViewTests(APITestCase):
         self.assertEqual(result["version"], environ["MARATHON_APP_VERSION"])
 
     @responses.activate
-    def test_send_wa_template_message(self):
-
-        org = Organization.objects.create(
-            name="Test Organization",
-            url="http://localhost:8002/",
-            token="REPLACEME",
-            engage_url="http://localhost:8005",
-            engage_token="REPLACEME",
-        )
-
-        responses.add(
-            responses.POST,
-            "http://localhost:8005/v1/messages",
-            json={
-                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
-                "meta": {"api_status": "stable", "version": "2.19.4"},
-            },
-            status=201,
-            match_querystring=True,
-        )
+    def test_send_wa_template_message_success_no_params(self):
+        org = self.mk_org()
+        self.add_whatsapp_messages_200_response(responses)
 
         params = {
             "org_id": org.id,
             "wa_id": "1234",
             "namespace": "test.namespace",
             "element_name": "el",
-            "message": "hey!",
         }
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
@@ -84,7 +90,44 @@ class SurveyCheckViewTests(APITestCase):
                     "namespace": "test.namespace",
                     "element_name": "el",
                     "language": {"policy": "fallback", "code": "en_US"},
-                    "localizable_params": [{"default": "hey!"}],
+                    "localizable_params": [],
+                },
+            },
+        )
+
+    @responses.activate
+    def test_send_wa_template_message_success_params(self):
+        org = self.mk_org()
+        self.add_whatsapp_messages_200_response(responses)
+
+        params = {
+            "org_id": org.id,
+            "wa_id": "1234",
+            "namespace": "test.namespace",
+            "element_name": "el",
+            "1": "R25",
+            "0": "Ola",
+        }
+
+        url = "{}?{}".format(reverse("send_template"), urlencode(params))
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        request_body = json.loads(responses.calls[0].request.body)
+        self.assertEqual(
+            request_body,
+            {
+                "to": "1234",
+                "type": "hsm",
+                "hsm": {
+                    "namespace": "test.namespace",
+                    "element_name": "el",
+                    "language": {"policy": "fallback", "code": "en_US"},
+                    "localizable_params": [
+                        {"default": "Ola"},
+                        {"default": "R25"},
+                    ],
                 },
             },
         )
@@ -95,23 +138,31 @@ class SurveyCheckViewTests(APITestCase):
             "wa_id": "1234",
             "namespace": "test.namespace",
             "element_name": "el",
-            "message": "hey!",
+            "0": "hey!",
         }
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        content = json.loads(response.content)
+        self.assertTrue("error" in content)
+        self.assertEquals(content["error"], "Organization not found")
 
     def test_send_wa_template_message_missing_params(self):
+        org = self.mk_org()
         params = {
-            "org_id": "2",
+            "org_id": org.id,
             "wa_id": "1234",
             "namespace": "test.namespace",
-            "element_name": "el",
+            #  missing param:
+            #  "element_name": "el",
         }
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        content = json.loads(response.content)
+        self.assertTrue("error" in content)
+        self.assertEquals(content["error"], "Missing fields: element_name")


### PR DESCRIPTION
Currently we only accept `message` as a parameter and pass that on to the templated message. This PR updates the veiw to use integer query params to indicate order of localized params. See updates to docs for more detail.