### PR TITLE
GPE-839 add check contact endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ VERSIONS
 
 Next Release
 ------------
+* Sidekick: Added a check contact endpoint for WhatsApp
 
 1.1.0
 ------------

--- a/docs/apps/sidekick.md
+++ b/docs/apps/sidekick.md
@@ -1,6 +1,9 @@
 # RP Sidekick
 The default Sidekick Module exists to provide shareable components across the various django applications, in particular the Org and User management. It also provides some miscellaneous functionality, in particular, the ability to send WhatsApp templated messages
 
+## Check WhatsApp Endpoint
+This endpoint, served at `/check_contact/<org_id>/<msisdn>/` serves as a wrapper for a single request to the [Turn contact check endpoint](https://whatsapp.praekelt.org/docs/index.html#contacts).
+
 ## WhatsApp Template Endpoint
 RapidPro does not yet provide first-class support for [WhatsApp templates](https://whatsapp.praekelt.org/docs/index.html#templated-messages), which means that they need to be sent via Sidekick, using a Webhook within RapidPro.
 

--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -101,7 +101,7 @@ class UtilsTests(TestCase):
         )
 
     @responses.activate
-    def test_get_whatsapp_contact_exists(self):
+    def test_get_whatsapp_contact_id_exists(self):
         org = self.create_org()
 
         responses.add(
@@ -120,7 +120,7 @@ class UtilsTests(TestCase):
         )
 
         self.assertEqual(
-            utils.get_whatsapp_contact(org, "+27820001001"), "27820001001"
+            utils.get_whatsapp_contact_id(org, "+27820001001"), "27820001001"
         )
         request = responses.calls[-1].request
         self.assertEqual(request.headers["Authorization"], "Bearer test-token")
@@ -130,7 +130,7 @@ class UtilsTests(TestCase):
         )
 
     @responses.activate
-    def test_get_whatsapp_contact_not_exists(self):
+    def test_get_whatsapp_contact_id_not_exists(self):
         org = self.create_org()
 
         responses.add(
@@ -140,7 +140,9 @@ class UtilsTests(TestCase):
             status=200,
         )
 
-        self.assertEqual(utils.get_whatsapp_contact(org, "+27820001001"), None)
+        self.assertEqual(
+            utils.get_whatsapp_contact_id(org, "+27820001001"), None
+        )
         request = responses.calls[-1].request
         self.assertEqual(request.headers["Authorization"], "Bearer test-token")
         self.assertEqual(
@@ -149,29 +151,29 @@ class UtilsTests(TestCase):
         )
 
     @responses.activate
-    @patch("sidekick.utils.get_whatsapp_contact")
+    @patch("sidekick.utils.get_whatsapp_contact_id")
     def test_update_rapidpro_whatsapp_urn_no_wa_id(
-        self, mock_get_whatsapp_contact
+        self, mock_get_whatsapp_contact_id
     ):
         msisdn = "+27820001001"
         org = self.create_org()
 
-        mock_get_whatsapp_contact.return_value = None
+        mock_get_whatsapp_contact_id.return_value = None
 
         utils.update_rapidpro_whatsapp_urn(org, msisdn)
 
         self.assertEqual(len(responses.calls), 0)
-        mock_get_whatsapp_contact.assert_called_with(org, msisdn)
+        mock_get_whatsapp_contact_id.assert_called_with(org, msisdn)
 
     @responses.activate
-    @patch("sidekick.utils.get_whatsapp_contact")
+    @patch("sidekick.utils.get_whatsapp_contact_id")
     def test_update_rapidpro_whatsapp_existing_contact_new_wa(
-        self, mock_get_whatsapp_contact
+        self, mock_get_whatsapp_contact_id
     ):
         org = self.create_org()
         msisdn = "+27820001001"
 
-        mock_get_whatsapp_contact.return_value = msisdn.replace("+", "")
+        mock_get_whatsapp_contact_id.return_value = msisdn.replace("+", "")
 
         self.mock_rapidpro_contact_get(msisdn)
         self.mock_rapidpro_contact_post(
@@ -193,14 +195,14 @@ class UtilsTests(TestCase):
         )
 
     @responses.activate
-    @patch("sidekick.utils.get_whatsapp_contact")
+    @patch("sidekick.utils.get_whatsapp_contact_id")
     def test_update_rapidpro_whatsapp_existing_contact_and_wa(
-        self, mock_get_whatsapp_contact
+        self, mock_get_whatsapp_contact_id
     ):
         org = self.create_org()
         msisdn = "+27820001001"
 
-        mock_get_whatsapp_contact.return_value = msisdn.replace("+", "")
+        mock_get_whatsapp_contact_id.return_value = msisdn.replace("+", "")
 
         self.mock_rapidpro_contact_get(msisdn, wa_id=msisdn.replace("+", ""))
         self.mock_rapidpro_contact_post(
@@ -212,14 +214,14 @@ class UtilsTests(TestCase):
         self.assertEqual(len(responses.calls), 1)
 
     @responses.activate
-    @patch("sidekick.utils.get_whatsapp_contact")
+    @patch("sidekick.utils.get_whatsapp_contact_id")
     def test_update_rapidpro_whatsapp_new_contact_and_wa(
-        self, mock_get_whatsapp_contact
+        self, mock_get_whatsapp_contact_id
     ):
         org = self.create_org()
         msisdn = "+27820001001"
 
-        mock_get_whatsapp_contact.return_value = msisdn.replace("+", "")
+        mock_get_whatsapp_contact_id.return_value = msisdn.replace("+", "")
 
         self.mock_rapidpro_contact_get(msisdn, count=0)
         self.mock_rapidpro_contact_post(msisdn, wa_id=msisdn.replace("+", ""))

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -68,7 +68,7 @@ class SidekickAPITestCase(APITestCase):
 
 
 class TestSendTemplateView(SidekickAPITestCase):
-    def add_whatsapp_messages_200_response(self, responses):
+    def add_whatsapp_messages_200_response(self):
         """
         Keep things DRY by reusing this snippet when testing WA response
         """
@@ -86,7 +86,7 @@ class TestSendTemplateView(SidekickAPITestCase):
     @responses.activate
     def test_send_wa_template_message_success_no_params(self):
         org = self.mk_org()
-        self.add_whatsapp_messages_200_response(responses)
+        self.add_whatsapp_messages_200_response()
 
         params = {
             "org_id": org.id,
@@ -118,7 +118,7 @@ class TestSendTemplateView(SidekickAPITestCase):
     @responses.activate
     def test_send_wa_template_message_success_params(self):
         org = self.mk_org()
-        self.add_whatsapp_messages_200_response(responses)
+        self.add_whatsapp_messages_200_response()
 
         params = {
             "org_id": org.id,

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -273,6 +273,34 @@ class TestCheckContactView(SidekickAPITestCase):
         self.assertTrue("status" in content)
         self.assertEquals(content["status"], "invalid")
 
+    @responses.activate
+    def test_wa_check_contact_error(self):
+        # set up
+        org = self.mk_org()
+        telephone_number = "+27820000001"
+
+        responses.add(
+            responses.POST,
+            "{}/v1/contacts".format(FAKE_ENGAGE_URL),
+            "Invalid WhatsApp Token",
+            status=status.HTTP_403_FORBIDDEN,
+            match_querystring=True,
+        )
+
+        # get result
+        response = self.api_client.get(
+            reverse(
+                "check_contact",
+                kwargs={"org_id": org.id, "msisdn": telephone_number},
+            )
+        )
+
+        # inspect response from Sidekick
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        content = json.loads(response.content)
+        self.assertTrue("error" in content)
+        self.assertEquals(content["error"], "Invalid WhatsApp Token")
+
     def test_wa_check_contact_no_org(self):
         # get result
         response = self.api_client.get(

--- a/sidekick/tests/test_views.py
+++ b/sidekick/tests/test_views.py
@@ -4,42 +4,24 @@ from os import environ
 from urllib.parse import urlencode
 
 from django.urls import reverse
+from django.contrib.auth import get_user_model
+
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
+from rest_framework.authtoken.models import Token
 
 from ..models import Organization
 
 
-class SidekickViewTests(APITestCase):
+FAKE_ENGAGE_URL = "http://localhost:8005"
+
+
+class HealthViewTest(APITestCase):
     def setUp(self):
-        self.client = APIClient()
-
-    def add_whatsapp_messages_200_response(self, responses):
-        """
-        Keep things DRY by reusing this snippet when testing WA response
-        """
-        responses.add(
-            responses.POST,
-            "http://localhost:8005/v1/messages",
-            json={
-                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
-                "meta": {"api_status": "stable", "version": "2.19.4"},
-            },
-            status=201,
-            match_querystring=True,
-        )
-
-    def mk_org(self):
-        return Organization.objects.create(
-            name="Test Organization",
-            url="http://localhost:8002/",
-            token="REPLACEME",
-            engage_url="http://localhost:8005",
-            engage_token="REPLACEME",
-        )
+        self.api_client = APIClient()
 
     def test_health_endpoint(self):
-        response = self.client.get(reverse("health"))
+        response = self.api_client.get(reverse("health"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         result = json.loads(response.content)
 
@@ -53,7 +35,7 @@ class SidekickViewTests(APITestCase):
         environ["MARATHON_APP_ID"] = "marathon-app-id"
         environ["MARATHON_APP_VERSION"] = "marathon-app-version"
 
-        response = self.client.get(reverse("health"))
+        response = self.api_client.get(reverse("health"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         result = json.loads(response.content)
 
@@ -62,6 +44,44 @@ class SidekickViewTests(APITestCase):
 
         self.assertTrue("version" in result)
         self.assertEqual(result["version"], environ["MARATHON_APP_VERSION"])
+
+
+class SidekickAPITestCase(APITestCase):
+    def setUp(self):
+        self.api_client = APIClient()
+
+        self.user = get_user_model().objects.create_superuser(
+            username="superuser", email="superuser@email.com", password="pass"
+        )
+        token = Token.objects.create(user=self.user)
+        self.token = token.key
+        self.api_client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+
+    def mk_org(self):
+        return Organization.objects.create(
+            name="Test Organization",
+            url="http://localhost:8002/",
+            token="REPLACEME",
+            engage_url=FAKE_ENGAGE_URL,
+            engage_token="REPLACEME",
+        )
+
+
+class TestSendTemplateView(SidekickAPITestCase):
+    def add_whatsapp_messages_200_response(self, responses):
+        """
+        Keep things DRY by reusing this snippet when testing WA response
+        """
+        responses.add(
+            responses.POST,
+            "{}/v1/messages".format(FAKE_ENGAGE_URL),
+            json={
+                "messages": [{"id": "sdkjfgksjfgoksdflgs"}],
+                "meta": {"api_status": "stable", "version": "2.19.4"},
+            },
+            status=201,
+            match_querystring=True,
+        )
 
     @responses.activate
     def test_send_wa_template_message_success_no_params(self):
@@ -77,7 +97,7 @@ class SidekickViewTests(APITestCase):
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
-        response = self.client.get(url)
+        response = self.api_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         request_body = json.loads(responses.calls[0].request.body)
@@ -111,7 +131,7 @@ class SidekickViewTests(APITestCase):
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
-        response = self.client.get(url)
+        response = self.api_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         request_body = json.loads(responses.calls[0].request.body)
@@ -143,7 +163,7 @@ class SidekickViewTests(APITestCase):
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
-        response = self.client.get(url)
+        response = self.api_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         content = json.loads(response.content)
         self.assertTrue("error" in content)
@@ -161,8 +181,108 @@ class SidekickViewTests(APITestCase):
 
         url = "{}?{}".format(reverse("send_template"), urlencode(params))
 
-        response = self.client.get(url)
+        response = self.api_client.get(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         content = json.loads(response.content)
         self.assertTrue("error" in content)
         self.assertEquals(content["error"], "Missing fields: element_name")
+
+
+class TestCheckContactView(SidekickAPITestCase):
+    @responses.activate
+    def test_wa_check_contact_valid(self):
+        # set up
+        org = self.mk_org()
+        telephone_number = "+27820000001"
+
+        responses.add(
+            responses.POST,
+            "{}/v1/contacts".format(FAKE_ENGAGE_URL),
+            json={
+                "contacts": [
+                    {
+                        "input": telephone_number,
+                        "status": "valid",
+                        "wa_id": telephone_number.replace("+", ""),
+                    }
+                ]
+            },
+            status=201,
+            match_querystring=True,
+        )
+
+        # get result
+        response = self.api_client.get(
+            reverse(
+                "check_contact",
+                kwargs={"org_id": org.id, "msisdn": telephone_number},
+            )
+        )
+
+        # inspect request to Turn
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        turn_request_body = json.loads(responses.calls[0].request.body)
+        self.assertEqual(
+            turn_request_body,
+            {"blocking": "wait", "contacts": [telephone_number]},
+        )
+
+        # inspect response from Sidekick
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        self.assertTrue("status" in content)
+        self.assertEquals(content["status"], "valid")
+
+    @responses.activate
+    def test_wa_check_contact_invalid(self):
+        # set up
+        org = self.mk_org()
+        telephone_number = "+27820000001"
+
+        responses.add(
+            responses.POST,
+            "{}/v1/contacts".format(FAKE_ENGAGE_URL),
+            json={
+                "contacts": [{"input": telephone_number, "status": "invalid"}]
+            },
+            status=201,
+            match_querystring=True,
+        )
+
+        # get result
+        response = self.api_client.get(
+            reverse(
+                "check_contact",
+                kwargs={"org_id": org.id, "msisdn": telephone_number},
+            )
+        )
+
+        # inspect request to Turn
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        turn_request_body = json.loads(responses.calls[0].request.body)
+        self.assertEqual(
+            turn_request_body,
+            {"blocking": "wait", "contacts": [telephone_number]},
+        )
+
+        # inspect response from Sidekick
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        self.assertTrue("status" in content)
+        self.assertEquals(content["status"], "invalid")
+
+    def test_wa_check_contact_no_org(self):
+        # get result
+        response = self.api_client.get(
+            reverse(
+                "check_contact", kwargs={"org_id": 99, "msisdn": "16315551003"}
+            )
+        )
+
+        # inspect response from Sidekick
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        content = json.loads(response.content)
+        self.assertTrue("error" in content)
+        self.assertEquals(content["error"], "Organization not found")

--- a/sidekick/urls.py
+++ b/sidekick/urls.py
@@ -5,4 +5,9 @@ from . import views
 urlpatterns = [
     path("health", views.health, name="health"),
     path("send_template", views.send_wa_template_message, name="send_template"),
+    path(
+        "check_contact/<int:org_id>/<str:msisdn>/",
+        views.CheckContactView.as_view(),
+        name="check_contact",
+    ),
 ]

--- a/sidekick/views.py
+++ b/sidekick/views.py
@@ -100,7 +100,8 @@ class CheckContactView(APIView):
         )
         if not (200 <= result.status_code and result.status_code < 300):
             return JsonResponse(
-                json.loads(result.content), status=result.status_code
+                {"error": result.content.decode("utf-8")},
+                status=result.status_code,
             )
 
         return JsonResponse(


### PR DESCRIPTION
[Turn](https://whatsapp.praekelt.org/docs/index.html#contacts) gives us an endpoint to check that an msisdn is associated with a valid WhatsApp account.

This adds an endpoint that returns whether a number is valid or invalid.

NOTE: 
- this PR also refactors the View Tests within the Django `sidekick` app, so that each TestClass tests a single url/view
- it also refactors some of the sidekick/utils so that we can reuse the contact check call to Turn