### PR TITLE
[GPE 839] add fail flow to buy_airtime_take_action task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ VERSIONS
 
 Next Release
 ------------
+* TransferTo: keep a record of topup requests to transferto with TopupAttempt model
+* TransferTo: start the participant on another rapidpro flow, if the request to TransferTo failed or was rejected in BuyAirtimeTakeAction task
 
 1.3.2
 ------------

--- a/docs/apps/transferto.md
+++ b/docs/apps/transferto.md
@@ -25,7 +25,8 @@ These endpoints will queue the request to TransferTo using celery. They will imm
 
 - `BuyAirtimeTakeAction`: this endpoint allows the user to
     - purchase airtime for a particular msisdn
-    - [optional] update a rapidpro contact's fields based on the response
-    - [optional] start the participant on another rapidpro flow, once the task has been completed.
+    - (optional) update a rapidpro contact's fields based on the response
+    - (optional) start the participant on another rapidpro flow, if the request to TransferTo was successful
+    - (optional) start the participant on another rapidpro flow, if the request to TransferTo failed or was rejected
 
     ! Note that the 'from' argument should not be longer than 15 characters as TransferTo will truncate the characters in the SMS that it sends.

--- a/rp_transferto/templates/rp_transferto/topup_airtime_take_action_email.html
+++ b/rp_transferto/templates/rp_transferto/topup_airtime_take_action_email.html
@@ -1,0 +1,21 @@
+Task Name: {{task_name}}
+Topup Attempt:
+{{topup_attempt | safe}}
+Values to Update:
+{{values_to_update | safe}}
+Flow to Start if Topup Successful: {{flow_start}}
+Flow to Start if Topup Failed: {{fail_flow_start}}
+
+TOPUP: {% if topup_attempt_failed %}FAILED{% else %}SUCCEEDED{% endif %}
+
+SHOULD UPDATE FIELDS: {{should_update_fields}}
+{% if should_update_fields %}status: {% if update_fields_successful %}SUCCEEDED{% else %}FAILED
+exception: {{update_fields_exception | safe}}{% endif %}{% endif %}
+
+SHOULD START SUCCESS FLOW: {{should_start_success_flow}}
+{% if should_start_success_flow %}status: {% if success_flow_started %}SUCCEEDED{% else %}FAILED
+exception: {{success_flow_started_exception | safe}}{% endif %}{% endif %}
+
+SHOULD START FAILURE FLOW: {{should_start_fail_flow}}
+{% if should_start_fail_flow %}status: {% if fail_flow_started %}SUCCEEDED{% else %}FAILED
+exception: {{fail_flow_started_exception | safe}}{% endif %}{% endif %}

--- a/rp_transferto/views.py
+++ b/rp_transferto/views.py
@@ -221,6 +221,7 @@ class BuyAirtimeTakeAction(APIView):
 
         flow_uuid_key = "flow_uuid"
         user_uuid_key = "user_uuid"
+        fail_flow_uuid_key = "fail_flow_start"
         data = dict(request.GET.dict())
 
         flow_start = request.GET.get(flow_uuid_key, False)
@@ -229,6 +230,9 @@ class BuyAirtimeTakeAction(APIView):
         user_uuid = request.GET.get(user_uuid_key, False)
         if user_uuid:
             del data[user_uuid_key]
+        fail_flow_start = request.GET.get(fail_flow_uuid_key, False)
+        if fail_flow_start:
+            del data[fail_flow_uuid_key]
         # remaining variables will be coerced from key:value mapping
         # which represents variable on rapidpro to update: variable from response
 
@@ -244,5 +248,6 @@ class BuyAirtimeTakeAction(APIView):
             topup_attempt_id=topup_attempt.id,
             values_to_update=data,
             flow_start=flow_start,
+            fail_flow_start=fail_flow_start,
         )
         return JsonResponse({"info_txt": "buy_airtime_take_action"})

--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -233,3 +233,21 @@ class UtilsTests(TestCase):
 
     def test_clean_msisdn_2(self):
         self.assertEqual(utils.clean_msisdn("2782653"), "2782653")
+
+    def test_get_flow_url_1(self):
+        base_url = "https://textit.io"
+        flow_uuid = "1234-asdf"
+        test_org = create_org(url=base_url)
+        self.assertEqual(
+            utils.get_flow_url(test_org, flow_uuid),
+            "{}/flow/editor/{}".format(base_url, flow_uuid),
+        )
+
+    def test_get_flow_url_2(self):
+        base_url = "https://textit.io/"
+        flow_uuid = "1234-asdf"
+        test_org = create_org(url=base_url)
+        self.assertEqual(
+            utils.get_flow_url(test_org, flow_uuid),
+            "{}flow/editor/{}".format(base_url, flow_uuid),
+        )

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -1,6 +1,7 @@
 import requests
 from django.utils import timezone
 from six.moves import urllib_parse
+from urllib.parse import urljoin
 from temba_client.v2 import TembaClient
 import pkg_resources
 
@@ -69,3 +70,7 @@ def update_rapidpro_whatsapp_urn(org, msisdn):
                 client.update_contact(contact=contact.uuid, urns=urns)
         else:
             client.create_contact(urns=urns)
+
+
+def get_flow_url(org, flow_uuid):
+    return urljoin(urljoin(org.url, "/flow/editor/"), flow_uuid)


### PR DESCRIPTION
- should the transferto request fail, we might want to start a different flow
- split out `take_action` into `update_values` and `start_flow methods`
- for each action we want to take, make sure that we're reporting if anything goes wrong and give as much information as possible via email
- use django template for email body
- the tests are not as neat or as DRY as they could be, erring on the side of test coverage here