### PR TITLE
Call create groups task and send message change

### DIFF
--- a/rp_asos/tasks.py
+++ b/rp_asos/tasks.py
@@ -247,37 +247,7 @@ class PatientDataCheck(BaseTask):
                     reminders.append(msg)
 
             if reminders:
-                urns = ["tel:{}".format(hospital.hospital_lead_urn)]
-                utils.update_rapidpro_whatsapp_urn(
-                    org, hospital.hospital_lead_urn
-                )
-
-                extra_info = {
-                    "hospital_name": hospital.name,
-                    "week": utils.get_current_week_number(),
-                    "reminder": "\n".join(reminders),
-                    "contact_name": hospital.hospital_lead_name,
-                }
-
-                rapidpro_client.create_flow_start(
-                    hospital.rapidpro_flow,
-                    urns,
-                    restart_participants=True,
-                    extra=extra_info,
-                )
-
-                if hospital.nomination_urn:
-                    urns = ["tel:{}".format(hospital.nomination_urn)]
-                    utils.update_rapidpro_whatsapp_urn(
-                        org, hospital.nomination_urn
-                    )
-                    extra_info["contact_name"] = hospital.nomination_name
-                    rapidpro_client.create_flow_start(
-                        hospital.rapidpro_flow,
-                        urns,
-                        restart_participants=True,
-                        extra=extra_info,
-                    )
+                hospital.send_message(reminders)
 
     def run(self, project_id, **kwargs):
         project = Project.objects.prefetch_related("hospitals").get(

--- a/rp_asos/tests/test_models.py
+++ b/rp_asos/tests/test_models.py
@@ -1,16 +1,12 @@
-import datetime
 import json
 import responses
 
 from django.test import TestCase
+from freezegun import freeze_time
 from mock import patch
 
 from rp_asos.models import Hospital
 from rp_redcap.tests.base import RedcapBaseTestCase
-
-
-def override_get_today():
-    return datetime.datetime.strptime("2018-06-06", "%Y-%m-%d").date()
 
 
 class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
@@ -135,6 +131,7 @@ class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
         mock_add_admin.assert_called_with(self.org, "group-id-5", "wa-id-2")
 
     @responses.activate
+    @freeze_time("2018-06-06 01:30:00")
     @patch("sidekick.utils.update_rapidpro_whatsapp_urn")
     def test_send_message_not_in_group(self, mock_update_wa_urn):
         responses.add(
@@ -157,8 +154,7 @@ class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
 
         hospital = self.create_hospital(nomination_urn=None)
 
-        with patch("sidekick.utils.get_today", override_get_today):
-            hospital.send_message(["Test message"])
+        hospital.send_message(["Test message"])
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(
@@ -179,6 +175,7 @@ class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
         mock_update_wa_urn.assert_called()
 
     @responses.activate
+    @freeze_time("2018-06-06 01:30:00")
     @patch("sidekick.utils.update_rapidpro_whatsapp_urn")
     def test_send_message_not_in_group_nominated_urn(self, mock_update_wa_urn):
         responses.add(
@@ -201,8 +198,7 @@ class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
 
         hospital = self.create_hospital()
 
-        with patch("sidekick.utils.get_today", override_get_today):
-            hospital.send_message(["Test message"])
+        hospital.send_message(["Test message"])
 
         self.assertEqual(len(responses.calls), 2)
 

--- a/rp_asos/views.py
+++ b/rp_asos/views.py
@@ -1,14 +1,19 @@
 from django.http import HttpResponse
+from rest_framework import status
 from rest_framework.views import APIView
 
-from .tasks import patient_data_check
-from rp_redcap.views import validate_project_start_task
+from .tasks import patient_data_check, create_hospital_groups
+from rp_redcap.views import validate_project
 
 
 class StartPatientDataCheckView(APIView):
     def post(self, request, project_id, *args, **kwargs):
-        return_status = validate_project_start_task(
-            project_id, request, patient_data_check
-        )
+        return_status = validate_project(project_id, request)
+
+        if return_status == status.HTTP_202_ACCEPTED:
+            chain = patient_data_check.s(project_id) | create_hospital_groups.s(
+                project_id
+            )
+            chain.delay()
 
         return HttpResponse(status=return_status)

--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -108,6 +108,22 @@ class UtilsTests(TestCase):
         self.assertEqual(headers["Content-Type"], "application/json")
 
     @responses.activate
+    def test_send_whatsapp_group_message(self):
+        group_id = "group_1"
+        message = "Hey!"
+
+        responses.add(
+            method=responses.POST,
+            url="http://whatsapp/v1/messages",
+            json={"messages": [{"id": "gBEGkYiEB1VXAglK1ZEqA1YKPrU"}]},
+            status=200,
+        )
+
+        result = utils.send_whatsapp_group_message(self.org, group_id, message)
+
+        self.assertEqual(result.status_code, 200)
+
+    @responses.activate
     def test_get_whatsapp_contact_id_exists(self):
         responses.add(
             method=responses.POST,

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -56,6 +56,22 @@ def send_whatsapp_template_message(
     )
 
 
+def send_whatsapp_group_message(org, group_id, message):
+    return requests.post(
+        urljoin(org.engage_url, "v1/messages"),
+        headers=build_turn_headers(org.engage_token),
+        data=json.dumps(
+            {
+                "recipient_type": "group",
+                "to": group_id,
+                "render_mentions": False,
+                "type": "text",
+                "text": {"body": message},
+            }
+        ),
+    )
+
+
 def get_whatsapp_contact_id(org, msisdn):
     """
     Returns the WhatsApp ID for the given MSISDN


### PR DESCRIPTION
New:
The `CreateHospitalGroups` task will run before the patient reminders.
The patient reminders will go to the group if the recipient is in the WA group.