### PR TITLE
Search by wa id before creating contact

### DIFF
--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -244,7 +244,7 @@ class UtilsTests(TestCase):
 
         utils.update_rapidpro_whatsapp_urn(self.org, "+27820001001")
 
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 3)
         request = responses.calls[-1].request
         self.assertEqual(
             json.loads(request.body),

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -112,6 +112,10 @@ def update_rapidpro_whatsapp_urn(org, msisdn):
 
     if whatsapp_id:
         contact = client.get_contacts(urn="tel:{}".format(msisdn)).first()
+        if not contact:
+            contact = client.get_contacts(
+                urn="whatsapp:{}".format(whatsapp_id)
+            ).first()
 
         urns = ["tel:{}".format(msisdn), "whatsapp:{}".format(whatsapp_id)]
 


### PR DESCRIPTION
Some contacts were created with WA ids instead of msisdns, this is to make sure we search by both.