### PR TITLE
Only update screening record if something actually changes

### DIFF
--- a/rp_asos/models.py
+++ b/rp_asos/models.py
@@ -160,6 +160,16 @@ class ScreeningRecord(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
+    def as_dict(self):
+        return {
+            "date": self.date.strftime("%Y-%m-%d") if self.date else "",
+            "week_1_case_count": self.week_1_case_count,
+            "week_2_case_count": self.week_2_case_count,
+            "week_3_case_count": self.week_3_case_count,
+            "week_4_case_count": self.week_4_case_count,
+            "total_eligible": self.total_eligible,
+        }
+
 
 class PatientRecord(models.Model):
 

--- a/rp_asos/tests/test_tasks.py
+++ b/rp_asos/tests/test_tasks.py
@@ -458,14 +458,25 @@ class SurveyCheckPatientTaskTests(RedcapBaseTestCase, TestCase):
             updated_at=datetime.datetime(2019, 1, 9, tzinfo=timezone.utc)
         )
 
+        # nothing changes, updated_at should stay the same
         record = SCREENING_RECORD_TEMPLATE.copy()
         record.update({"date": "2018-06-06"})
-
         patient_data_check.save_screening_records(hospital, [record])
 
         screening_record = ScreeningRecord.objects.all()[0]
         self.assertEqual(ScreeningRecord.objects.all().count(), 1)
         self.assertEqual(
+            screening_record.updated_at,
+            datetime.datetime(2019, 1, 9, tzinfo=timezone.utc),
+        )
+
+        # something will change, updated_at should have new timestamp
+        record.update({"day1": "100"})
+        patient_data_check.save_screening_records(hospital, [record])
+
+        screening_record = ScreeningRecord.objects.all()[0]
+        self.assertEqual(ScreeningRecord.objects.all().count(), 1)
+        self.assertNotEqual(
             screening_record.updated_at,
             datetime.datetime(2019, 1, 9, tzinfo=timezone.utc),
         )


### PR DESCRIPTION
We only want to update the screening record if something actually changes, the update puts a timestamp in the updated_at field and we use that to make sure the leads are updating the screening record.