### PR TITLE
Refactor hospital WA groups task

### DIFF
--- a/rp_asos/models.py
+++ b/rp_asos/models.py
@@ -67,10 +67,9 @@ class Hospital(models.Model):
             group_info["id"] = self.whatsapp_group_id
         return group_info
 
-    def send_group_invites(self, group_info, msisdns):
+    def send_group_invites(self, group_info, wa_ids):
         invites = []
-        for msisdn in msisdns:
-            wa_id = utils.get_whatsapp_contact_id(self.project.org, msisdn)
+        for wa_id in wa_ids:
             if wa_id and wa_id not in group_info["participants"]:
                 invites.append(wa_id)
 
@@ -92,9 +91,14 @@ class Hospital(models.Model):
                         }
                     ],
                 )
-        return invites
 
-    def add_group_admins(self, group_info, wa_ids):
+    def add_group_admins(self, group_info, msisdns):
+        wa_ids = []
+        for msisdn in msisdns:
+            wa_id = utils.get_whatsapp_contact_id(self.project.org, msisdn)
+            if wa_id:
+                wa_ids.append(wa_id)
+
         for wa_id in wa_ids:
             if (
                 wa_id in group_info["participants"]
@@ -103,6 +107,8 @@ class Hospital(models.Model):
                 utils.add_whatsapp_group_admin(
                     self.project.org, group_info["id"], wa_id
                 )
+
+        return wa_ids
 
     def send_message(self, message):
         group_info = self.get_wa_group_info()

--- a/rp_asos/models.py
+++ b/rp_asos/models.py
@@ -67,31 +67,6 @@ class Hospital(models.Model):
             group_info["id"] = self.whatsapp_group_id
         return group_info
 
-    def send_group_invites(self, group_info, wa_ids):
-        invites = []
-        for wa_id in wa_ids:
-            if wa_id and wa_id not in group_info["participants"]:
-                invites.append(wa_id)
-
-        if invites:
-            invite_link = utils.get_whatsapp_group_invite_link(
-                self.project.org, group_info["id"]
-            )
-            for wa_id in invites:
-                utils.send_whatsapp_template_message(
-                    self.project.org,
-                    wa_id,
-                    "whatsapp:hsm:npo:praekeltpbc",
-                    "asos2_notification_v2",
-                    [
-                        {
-                            "default": "Hi, please join the ASOS2 Whatsapp group: {}".format(
-                                invite_link
-                            )
-                        }
-                    ],
-                )
-
     def add_group_admins(self, group_info, msisdns):
         wa_ids = []
         for msisdn in msisdns:

--- a/rp_asos/tasks.py
+++ b/rp_asos/tasks.py
@@ -307,7 +307,7 @@ def create_hospital_group(hospital_id):
 
     invites = []
     for wa_id in wa_ids:
-        if wa_id and wa_id not in group_info["participants"]:
+        if wa_id not in group_info["participants"]:
             invites.append(wa_id)
 
     if invites:

--- a/rp_asos/tests/test_models.py
+++ b/rp_asos/tests/test_models.py
@@ -193,36 +193,6 @@ class TestHospitalModelTask(RedcapBaseTestCase, TestCase):
         self.assertEqual(group_info, {"participants": [], "admins": []})
         mock_get_whatsapp_group_info.assert_not_called()
 
-    @patch("sidekick.utils.send_whatsapp_template_message")
-    @patch("sidekick.utils.get_whatsapp_group_invite_link")
-    def test_invites_noop(self, mock_get_invite_link, mock_send):
-        hospital = self.create_hospital()
-
-        hospital.send_group_invites({"participants": ["wa-id-1"]}, ["wa-id-1"])
-
-        mock_get_invite_link.assert_not_called()
-        mock_send.assert_not_called()
-
-    @patch("sidekick.utils.send_whatsapp_template_message")
-    @patch("sidekick.utils.get_whatsapp_group_invite_link")
-    def test_invites_send(self, mock_get_invite_link, mock_send):
-        mock_get_invite_link.return_value = "test-link"
-
-        hospital = self.create_hospital()
-
-        hospital.send_group_invites(
-            {"id": "group-id-4", "participants": ["wa-id-2"]}, ["wa-id-1"]
-        )
-
-        mock_get_invite_link.assert_called_with(self.org, "group-id-4")
-        mock_send.assert_called_with(
-            self.org,
-            "wa-id-1",
-            "whatsapp:hsm:npo:praekeltpbc",
-            "asos2_notification_v2",
-            [{"default": "Hi, please join the ASOS2 Whatsapp group: test-link"}],
-        )
-
     @patch("sidekick.utils.get_whatsapp_contact_id")
     @patch("sidekick.utils.add_whatsapp_group_admin")
     def test_add_admins_noop(self, mock_add_admin, mock_get_wa_id):

--- a/rp_asos/tests/test_tasks.py
+++ b/rp_asos/tests/test_tasks.py
@@ -552,6 +552,24 @@ class CreateHospitalGroupsTaskTests(RedcapBaseTestCase, TestCase):
         mock_get_info.assert_not_called()
         mock_create_group.assert_not_called()
 
+    @patch("rp_asos.models.Hospital.create_hospital_wa_group")
+    @patch("rp_asos.models.Hospital.get_wa_group_info")
+    @patch("sidekick.utils.send_whatsapp_template_message")
+    @patch("rp_asos.models.Hospital.add_group_admins")
+    def test_create_hospitals_group_no_invites(
+        self, mock_add_admins, mock_send_invite, mock_get_info, mock_create_group
+    ):
+        self.create_hospital(whatsapp_group_id="group-id-a")
+
+        group_info = {"id": "group-id-a", "participants": ["27123"]}
+
+        mock_get_info.return_value = group_info
+        mock_add_admins.return_value = ["27123"]
+
+        create_hospital_groups(str(self.project.id), "CAT")
+
+        mock_send_invite.assert_not_called()
+
     @patch("sidekick.utils.get_whatsapp_group_invite_link")
     @patch("rp_asos.models.Hospital.create_hospital_wa_group")
     @patch("rp_asos.models.Hospital.get_wa_group_info")

--- a/rp_asos/tests/test_tasks.py
+++ b/rp_asos/tests/test_tasks.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
-from mock import patch
+from mock import call, patch
 
 from rp_asos.models import Hospital, PatientRecord, PatientValue, ScreeningRecord
 from rp_asos.tasks import (
@@ -538,61 +538,119 @@ class CreateHospitalGroupsTaskTests(RedcapBaseTestCase, TestCase):
 
     @patch("rp_asos.models.Hospital.create_hospital_wa_group")
     @patch("rp_asos.models.Hospital.get_wa_group_info")
-    @patch("rp_asos.models.Hospital.send_group_invites")
+    @patch("sidekick.utils.send_whatsapp_template_message")
     @patch("rp_asos.models.Hospital.add_group_admins")
     def test_create_hospitals_group_noop(
-        self, mock_add_admins, mock_send_invites, mock_get_info, mock_create_group
+        self, mock_add_admins, mock_send_invite, mock_get_info, mock_create_group
     ):
         self.create_hospital(tz_code="NOT_CAT")
 
         create_hospital_groups(str(self.project.id), "CAT")
 
         mock_add_admins.assert_not_called()
-        mock_send_invites.assert_not_called()
+        mock_send_invite.assert_not_called()
         mock_get_info.assert_not_called()
         mock_create_group.assert_not_called()
 
+    @patch("sidekick.utils.get_whatsapp_group_invite_link")
     @patch("rp_asos.models.Hospital.create_hospital_wa_group")
     @patch("rp_asos.models.Hospital.get_wa_group_info")
-    @patch("rp_asos.models.Hospital.send_group_invites")
+    @patch("sidekick.utils.send_whatsapp_template_message")
     @patch("rp_asos.models.Hospital.add_group_admins")
     def test_create_hospitals_group_with_nomination(
-        self, mock_add_admins, mock_send_invites, mock_get_info, mock_create_group
+        self,
+        mock_add_admins,
+        mock_send_invite,
+        mock_get_info,
+        mock_create_group,
+        mock_get_invite_link,
     ):
-        hospital = self.create_hospital(whatsapp_group_id="group-id-a")
+        self.create_hospital(whatsapp_group_id="group-id-a")
 
-        mock_create_group.return_value = hospital
-        mock_get_info.return_value = {"id": "group-id-a"}
+        group_info = {"id": "group-id-a", "participants": []}
+
+        mock_get_info.return_value = group_info
         mock_add_admins.return_value = ["27123", "27321"]
+        mock_get_invite_link.return_value = "test-link"
 
         create_hospital_groups(str(self.project.id), "CAT")
 
-        mock_create_group.assert_called_with()
-        mock_get_info.assert_called_with()
-        mock_add_admins.assert_called_with({"id": "group-id-a"}, ["+27123", "+27321"])
-        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["27123", "27321"])
+        mock_create_group.assert_called_once()
+        mock_get_info.assert_called_once()
+        mock_add_admins.assert_called_with(group_info, ["+27123", "+27321"])
+        mock_send_invite.assert_has_calls(
+            [
+                call(
+                    self.org,
+                    "27123",
+                    "whatsapp:hsm:npo:praekeltpbc",
+                    "asos2_notification_v2",
+                    [
+                        {
+                            "default": "Hi, please join the ASOS2 Whatsapp group: test-link"
+                        }
+                    ],
+                ),
+                call(
+                    self.org,
+                    "27321",
+                    "whatsapp:hsm:npo:praekeltpbc",
+                    "asos2_notification_v2",
+                    [
+                        {
+                            "default": "Hi, please join the ASOS2 Whatsapp group: test-link"
+                        }
+                    ],
+                ),
+            ]
+        )
+        mock_get_invite_link.assert_called_once()
 
+    @patch("sidekick.utils.get_whatsapp_group_invite_link")
     @patch("rp_asos.models.Hospital.create_hospital_wa_group")
     @patch("rp_asos.models.Hospital.get_wa_group_info")
-    @patch("rp_asos.models.Hospital.send_group_invites")
+    @patch("sidekick.utils.send_whatsapp_template_message")
     @patch("rp_asos.models.Hospital.add_group_admins")
     def test_create_hospitals_group_with_lead_only(
-        self, mock_add_admins, mock_send_invites, mock_get_info, mock_create_group
+        self,
+        mock_add_admins,
+        mock_send_invite,
+        mock_get_info,
+        mock_create_group,
+        mock_get_invite_link,
     ):
         hospital = self.create_hospital(
             nomination_urn=None, whatsapp_group_id="group-id-a"
         )
 
+        group_info = {"id": "group-id-a", "participants": []}
+
         mock_create_group.return_value = hospital
-        mock_get_info.return_value = {"id": "group-id-a"}
+        mock_get_info.return_value = group_info
         mock_add_admins.return_value = ["27123"]
+        mock_get_invite_link.return_value = "test-link"
 
         create_hospital_groups(str(self.project.id), "CAT")
 
-        mock_create_group.assert_called_with()
-        mock_get_info.assert_called_with()
-        mock_add_admins.assert_called_with({"id": "group-id-a"}, ["+27123"])
-        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["27123"])
+        mock_create_group.assert_called_once()
+        mock_get_info.assert_called_once()
+        mock_add_admins.assert_called_with(group_info, ["+27123"])
+        mock_send_invite.assert_has_calls(
+            [
+                call(
+                    self.org,
+                    "27123",
+                    "whatsapp:hsm:npo:praekeltpbc",
+                    "asos2_notification_v2",
+                    [
+                        {
+                            "default": "Hi, please join the ASOS2 Whatsapp group: test-link"
+                        }
+                    ],
+                )
+            ]
+        )
+        mock_get_invite_link.assert_called_once()
 
 
 class ScreeningRecordTaskTests(RedcapBaseTestCase, TestCase):

--- a/rp_asos/tests/test_tasks.py
+++ b/rp_asos/tests/test_tasks.py
@@ -563,14 +563,14 @@ class CreateHospitalGroupsTaskTests(RedcapBaseTestCase, TestCase):
 
         mock_create_group.return_value = hospital
         mock_get_info.return_value = {"id": "group-id-a"}
-        mock_send_invites.return_value = ["+27123", "+27321"]
+        mock_add_admins.return_value = ["27123", "27321"]
 
         create_hospital_groups(str(self.project.id), "CAT")
 
         mock_create_group.assert_called_with()
         mock_get_info.assert_called_with()
-        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["+27123", "+27321"])
         mock_add_admins.assert_called_with({"id": "group-id-a"}, ["+27123", "+27321"])
+        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["27123", "27321"])
 
     @patch("rp_asos.models.Hospital.create_hospital_wa_group")
     @patch("rp_asos.models.Hospital.get_wa_group_info")
@@ -585,14 +585,14 @@ class CreateHospitalGroupsTaskTests(RedcapBaseTestCase, TestCase):
 
         mock_create_group.return_value = hospital
         mock_get_info.return_value = {"id": "group-id-a"}
-        mock_send_invites.return_value = ["+27123"]
+        mock_add_admins.return_value = ["27123"]
 
         create_hospital_groups(str(self.project.id), "CAT")
 
         mock_create_group.assert_called_with()
         mock_get_info.assert_called_with()
-        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["+27123"])
         mock_add_admins.assert_called_with({"id": "group-id-a"}, ["+27123"])
+        mock_send_invites.assert_called_with({"id": "group-id-a"}, ["27123"])
 
 
 class ScreeningRecordTaskTests(RedcapBaseTestCase, TestCase):

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -136,7 +136,7 @@ def create_whatsapp_group(org, subject):
         headers=build_turn_headers(org.engage_token),
         data=json.dumps({"subject": subject}),
     )
-
+    result.raise_for_status()
     return json.loads(result.content)["groups"][0]["id"]
 
 
@@ -148,6 +148,7 @@ def get_whatsapp_group_invite_link(org, group_id):
         urljoin(org.engage_url, "v1/groups/{}/invite".format(group_id)),
         headers=build_turn_headers(org.engage_token),
     )
+    response.raise_for_status()
     return json.loads(response.content)["groups"][0]["link"]
 
 
@@ -159,7 +160,7 @@ def get_whatsapp_group_info(org, group_id):
         urljoin(org.engage_url, "v1/groups/{}".format(group_id)),
         headers=build_turn_headers(org.engage_token),
     )
-
+    result.raise_for_status()
     return json.loads(result.content)["groups"][0]
 
 
@@ -167,11 +168,13 @@ def add_whatsapp_group_admin(org, group_id, wa_id):
     """
     Adds a existing Whatsapp group member to the list of admins on the group
     """
-    return requests.patch(
+    result = requests.patch(
         urljoin(org.engage_url, "v1/groups/{}/admins".format(group_id)),
         headers=build_turn_headers(org.engage_token),
         data=json.dumps({"wa_ids": [wa_id]}),
     )
+    result.raise_for_status()
+    return result
 
 
 def get_flow_url(org, flow_uuid):


### PR DESCRIPTION
This PR splits the hospital WA groups task into two separate tasks with a retry strategy for the one doing all the api requests.

I also added raise for status in the WA group funcitons