### PR TITLE
Allow spaces in variables submitted to whatsapp template endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ VERSIONS
 
 Next Release
 ------------
+Sidekick: Allow space character to be submitted as variables to whatsapp template endpoint
 
 1.5.10
 ------------

--- a/sidekick/views.py
+++ b/sidekick/views.py
@@ -26,7 +26,7 @@ from .tasks import (
     archive_turn_conversation,
     start_flow_task,
 )
-from .utils import clean_message, get_whatsapp_contacts, send_whatsapp_template_message
+from .utils import get_whatsapp_contacts, send_whatsapp_template_message
 
 
 def health(request):
@@ -92,7 +92,7 @@ class SendWhatsAppTemplateMessageView(APIView):
             )
 
         localizable_params = [
-            {"default": clean_message(data[_key])}
+            {"default": data[_key]}
             for _key in sorted([key for key in data.keys() if key.isdigit()])
         ]
 


### PR DESCRIPTION
Whatsapp does not allow us to submit `""` as a variable, so as a work around we want to submit `" "` for now. In order to do this, we should not use the `clean_message` function as it will convert `" "` to `""`