### PR TITLE
Reference last inbound for archiving turn conversation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ VERSIONS
 
 Next Release
 ------------
+Sidekick: Bugfix, reference last inbound message, not last message, for archiving Turn conversation
 
 1.6.0
 ------------

--- a/sidekick/tasks.py
+++ b/sidekick/tasks.py
@@ -60,6 +60,10 @@ def archive_turn_conversation(org_id, wa_id, reason):
     org = Organization.objects.get(id=org_id)
 
     result = get_whatsapp_contact_messages(org, wa_id)
-    last_message = max(result["messages"], key=lambda m: m.get("timestamp"))
+    inbounds = filter(
+        lambda m: m.get("_vnd", {}).get("v1", {}).get("direction") == "inbound",
+        result["messages"],
+    )
+    last_inbound_message = max(inbounds, key=lambda m: m.get("timestamp"))
 
-    archive_whatsapp_conversation(org, wa_id, last_message["id"], reason)
+    archive_whatsapp_conversation(org, wa_id, last_inbound_message["id"], reason)

--- a/sidekick/tests/test_tasks.py
+++ b/sidekick/tests/test_tasks.py
@@ -72,6 +72,11 @@ class ArchiveTurnConversationTests(TestCase):
                     "id": "second-inbound",
                     "timestamp": "3",
                 },
+                {
+                    "_vnd": {"v1": {"direction": "outbound"}},
+                    "id": "ignore-outbound-2",
+                    "timestamp": "4",
+                },
             ]
         }
         archive.return_value = {}


### PR DESCRIPTION
When archiving a Turn conversation, in order for the archiving to be successful, you need to reference the last inbound message. Referencing an outbound message id results in the conversation not being archived