### PR TITLE
Fiix clean_message util function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ VERSIONS
 
 Next Release
 ------------
+Sidekick: Allow space character to be submitted as variables to whatsapp template endpoint
 
 1.7.0
 ------------

--- a/sidekick/tests/test_utils.py
+++ b/sidekick/tests/test_utils.py
@@ -26,6 +26,9 @@ class UtilsTests(TestCase):
             "No new lines No tabs No huge spaces",
         )
 
+    def test_clean_message_empty_space(self):
+        self.assertEqual(utils.clean_message(" "), " ")
+
     def test_build_turn_headers(self):
         distribution = pkg_resources.get_distribution("rp-sidekick")
 

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from urllib.parse import urljoin
 
 import pkg_resources
@@ -22,7 +23,7 @@ def get_current_week_number():
 
 
 def clean_message(message):
-    return " ".join(message.replace("\n", " ").replace("\t", " ").split()) or " "
+    return re.sub(r"\W+", " ", message)
 
 
 def clean_msisdn(msisdn):

--- a/sidekick/utils.py
+++ b/sidekick/utils.py
@@ -22,7 +22,7 @@ def get_current_week_number():
 
 
 def clean_message(message):
-    return " ".join(message.replace("\n", " ").replace("\t", " ").split())
+    return " ".join(message.replace("\n", " ").replace("\t", " ").split()) or " "
 
 
 def clean_msisdn(msisdn):

--- a/sidekick/views.py
+++ b/sidekick/views.py
@@ -26,7 +26,7 @@ from .tasks import (
     archive_turn_conversation,
     start_flow_task,
 )
-from .utils import get_whatsapp_contacts, send_whatsapp_template_message
+from .utils import clean_message, get_whatsapp_contacts, send_whatsapp_template_message
 
 
 def health(request):
@@ -92,7 +92,7 @@ class SendWhatsAppTemplateMessageView(APIView):
             )
 
         localizable_params = [
-            {"default": data[_key]}
+            {"default": clean_message(data[_key])}
             for _key in sorted([key for key in data.keys() if key.isdigit()])
         ]
 


### PR DESCRIPTION
Over here https://github.com/praekeltfoundation/rp-sidekick/pull/100 we removed the `clean_message` to be able to send empty spaces as variables for a templated message.

This meant messages weren't being cleaned of spaces, tabs and new lines.

It will now clean and return an empty space if necessary.