### PR TITLE
GP Connect bug fixes

### DIFF
--- a/rp_gpconnect/tasks.py
+++ b/rp_gpconnect/tasks.py
@@ -64,7 +64,7 @@ def import_or_update_contact(patient_info, org_id):
     org = Organization.objects.get(id=org_id)
     client = TembaClient(org.url, org.token)
 
-    msisdn = patient_info.pop("msisdn")
+    msisdn = patient_info.pop("telephone_no")
     urns = ["tel:{}".format(msisdn)]
 
     whatsapp_id = get_whatsapp_contact_id(org, msisdn)

--- a/rp_gpconnect/tasks.py
+++ b/rp_gpconnect/tasks.py
@@ -81,7 +81,7 @@ def import_or_update_contact(patient_info, org_id):
     if contact:
         if urns != contact.urns:
             contact = client.update_contact(contact=contact.uuid, urns=urns)
-        if contact.fields != patient_info:
+        if not patient_info.items() <= contact.fields.items():
             client.create_flow_start(
                 flow=org.flows.get(type="contact_update").rapidpro_flow,
                 urns=urns,

--- a/rp_gpconnect/tests/test_task.py
+++ b/rp_gpconnect/tests/test_task.py
@@ -260,6 +260,12 @@ class ImportOrUpdateContactTaskTests(TestCase):
         mock_contact_object.urns = ["tel:+27000000001"]
         mock_get_rp_contact.return_value.first.return_value = mock_contact_object
 
+        mock_updated_object = Mock()
+        mock_updated_object.uuid = "123456"
+        mock_updated_object.urns = ["tel:+27000000001", "whatsapp:27000000001"]
+        mock_updated_object.fields = {"has_whatsapp": True}
+        mock_update_rp_contact.return_value = mock_updated_object
+
         import_or_update_contact(
             {"telephone_no": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
         )

--- a/rp_gpconnect/tests/test_task.py
+++ b/rp_gpconnect/tests/test_task.py
@@ -21,7 +21,7 @@ from sidekick.tests.utils import assertCallMadeWith
 def create_temp_xlsx_file(temp_file, msisdns):
     wb = Workbook()
     sheet = wb.create_sheet("GP Connect daily report", 0)
-    sheet["A1"] = "msisdn"
+    sheet["A1"] = "telephone_no"
     sheet["B1"] = "something_else"
     sheet["C1"] = "patients_tested_positive"
     for x in range(len(msisdns)):
@@ -177,7 +177,7 @@ class ProcessContactImportTaskTests(TestCase):
         self.assertEqual(mock_contact_update_task.call_count, 2)
         mock_contact_update_task.assert_any_call(
             {
-                "msisdn": "+27000000002",
+                "telephone_no": "+27000000002",
                 "something_else": "stuuuuff",
                 "patients_tested_positive": 1,
             },
@@ -185,7 +185,7 @@ class ProcessContactImportTaskTests(TestCase):
         )
         mock_contact_update_task.assert_any_call(
             {
-                "msisdn": "+27000000004",
+                "telephone_no": "+27000000004",
                 "something_else": "stuuuuff",
                 "patients_tested_positive": 1,
             },
@@ -232,7 +232,7 @@ class ImportOrUpdateContactTaskTests(TestCase):
         mock_get_rp_contact.return_value.first.return_value = mock_contact_object
 
         import_or_update_contact(
-            {"msisdn": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
+            {"telephone_no": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
         )
 
         mock_get_whatsapp_contact_id.assert_called_with(self.org, "+27000000001")
@@ -261,7 +261,7 @@ class ImportOrUpdateContactTaskTests(TestCase):
         mock_get_rp_contact.return_value.first.return_value = mock_contact_object
 
         import_or_update_contact(
-            {"msisdn": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
+            {"telephone_no": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
         )
         mock_get_whatsapp_contact_id.assert_called_with(self.org, "+27000000001")
 
@@ -297,7 +297,7 @@ class ImportOrUpdateContactTaskTests(TestCase):
         mock_get_rp_contact.return_value.first.side_effect = [None, None]
 
         import_or_update_contact(
-            {"msisdn": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
+            {"telephone_no": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
         )
 
         self.assertEqual(mock_get_rp_contact.call_count, 1)
@@ -331,7 +331,7 @@ class ImportOrUpdateContactTaskTests(TestCase):
         mock_get_rp_contact.return_value.first.side_effect = [None, None]
 
         import_or_update_contact(
-            {"msisdn": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
+            {"telephone_no": "+27000000001", "something_else": "stuuuuff"}, self.org.pk
         )
 
         self.assertEqual(mock_get_rp_contact.call_count, 2)


### PR DESCRIPTION
Minor bugfixes for GP connect contact upload

The first change is simply changing the expected column name for the msisdn column.
The second change ensures that the check for any changes in the patient info doesn't care about other RapidPro contact fields
