### PR TITLE
Create media directory for gpconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM praekeltfoundation/django-bootstrap:py3.6
 
 COPY . /app
+RUN mkdir -p /app/media/uploads/gpconnect/
+
 RUN pip install -e .
 
 # temporary untill there is a new PyCap Release


### PR DESCRIPTION
the upload task is throwing this error because the directory doesn't exist
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/rp_gpconnect/tasks.py", line 121, in pull_new_import_file
    os.path.join(settings.MEDIA_ROOT, matching_name), "wb"
FileNotFoundError: [Errno 2] No such file or directory: '/app/media/uploads/gpconnect/test_sheet.xlsx'
```