### PR TITLE
Add an endpoint to get only contact uuids

### DIFF
--- a/sidekick/urls.py
+++ b/sidekick/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
         views.ArchiveTurnConversationView.as_view(),
         name="archive-turn-conversation",
     ),
+    path(
+        "api/list_contacts/<int:pk>/",
+        views.ListContactsView.as_view(),
+        name="list_contacts",
+    ),
 ]


### PR DESCRIPTION
RapidPro Webhooks can only handle responses smaller than 10kb.
The RP contacts api returns all the information for every contact requested. That means that it very quickly exceeds this 10kb limit when called from a webhook (+- 15 contacts)
We need an intermediary that will filter out the information we don't need.