### PR TITLE
Ensure GP con tasks only run if settings exist

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -173,13 +173,14 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 
-CELERYBEAT_SCHEDULE = {
-    "rp_gpconnect_find_new_import_file": {
+CELERYBEAT_SCHEDULE = {}
+
+if GP_CONNECT_FILE_DIR:
+    CELERYBEAT_SCHEDULE["rp_gpconnect_find_new_import_file"] = {
         "task": "rp_gpconnect.tasks.pull_new_import_file",
         "schedule": crontab(minute="0", hour="*"),
         "kwargs": {"upload_dir": GP_CONNECT_FILE_DIR, "org_name": GP_CONNECT_ORG_NAME},
     }
-}
 
 djcelery.setup_loader()
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -144,8 +144,8 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
 }
 
-GP_CONNECT_FILE_DIR = env.str("GP_CONNECT_FILE_DIR", "uploads/")
-GP_CONNECT_ORG_NAME = env.str("GP_CONNECT_ORG_NAME", "GP Connect")
+GP_CONNECT_FILE_DIR = env.str("GP_CONNECT_FILE_DIR", "")
+GP_CONNECT_ORG_NAME = env.str("GP_CONNECT_ORG_NAME", "")
 AWS_ACCESS_KEY_ID = env.str("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = env.str("AWS_SECRET_ACCESS_KEY", "")
 AWS_STORAGE_BUCKET_NAME = env.str("AWS_STORAGE_BUCKET_NAME", "")


### PR DESCRIPTION
This change ensures that the GP Connect contact import tasks will not be run by celery beat if the settings don't exist.