### PR TITLE
pointing celery task to rp_transferto

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -163,6 +163,9 @@ CELERY_QUEUES = (
 
 CELERY_ALWAYS_EAGER = False
 
+# Tell Celery where to find the tasks
+CELERY_IMPORTS = ("rp_transferto.tasks",)
+
 CELERY_CREATE_MISSING_QUEUES = True
 CELERY_ROUTES = {"celery.backend_cleanup": {"queue": "mediumpriority"}}
 


### PR DESCRIPTION
Point celery task to rp_transferto