### PR TITLE
Add page view caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,10 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
+      redis:
+        image: redis:6.0
+        ports:
+          - 6379:6379
     env:
       RP_SIDEKICK_DATABASE: postgres://postgres:postgres@localhost/rp_sidekick
     steps:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -223,3 +223,5 @@ sentry_sdk.init(
     # something more human-readable.
     # release="myapp@1.0.0",
 )
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "phonenumbers==8.10.23",
         "psycopg2-binary==2.8.6",
         "rapidpro-python==2.6.1",
-        "redis==4.4.4",
+        "redis==4.5.4",
         "whitenoise==4.1.4",
         "raven==6.10.0",
         "hashids==1.3.1",


### PR DESCRIPTION
`/orderedcontent/` gets called multiple times per contact for figuring out what content to send.

`get_unique_page_seen_ids` does a call to the contentrepo that take 5-8 seconds to complete and we tried adding a index but there is nothing else we can do to improve the performance.

We're now caching the results for 5 hours and returning it to rapidpro where we will replace another page view call.